### PR TITLE
Using Effects in query-json (draft)

### DIFF
--- a/src/content/posts/effect-in-query-json.mdx
+++ b/src/content/posts/effect-in-query-json.mdx
@@ -9,17 +9,19 @@ tags:
   - "query-json"
 ---
 
-A few years ago I wrote [query-json](/posts/cross-compile-query-json), a re-implementation of subset of jq in OCaml. Back then, the interpreter was straightforward: a function that took an jq expression and a JSON, and returned a JSON.
+A few years ago I wrote [query-json](/posts/cross-compile-query-json), a reimplementation of a subset of jq in OCaml. Back then, the interpreter was straightforward: a function that took a jq expression and a JSON value and returned a JSON value.
 
-{/* add jq notation, example, whatever to give context */}
+If you know how `try/catch` works in any other language, you already have the core intuition for this post. Effects generalize that model in exactly one way, and that one difference is the whole story.
 
-Since then, query-json grew into implementing most of jq's language: `try/catch`, `while`, `limit`, user-defined functions, expressions can produce zero, one, or many results. Those expressions can fail, halt the program, break out of loops, and a long etcetera of a complete programming language. jq is actually [Turing-complete](https://github.com/MakeNowJust/bf.jq) (someone wrote a Brainfuck interpreter in it, if you need convincing). The design I started with ("take an expression, return a value") couldn't handle any of this.
+If you have never used jq: a jq filter is an expression that takes JSON in and produces JSON out. `.name` extracts a field, `.users[]` iterates over an array, and `|` pipes the output of one filter into the next as its input. query-json implements that same filter language.
 
-In this post I want to explain the evolution and implementation to handle those control-flow patterns and how OCaml effect system helped. If you know how `try/catch` works in any other language, you don't need anything else to understand effects.
+Since then, query-json grew into most of jq's language: `try/catch`, `while`, `limit`, user-defined functions, and expressions that produce zero, one, or many results. Those expressions can fail, halt the program, break out of loops, and carry the rest of the control-flow repertoire you would expect from a complete programming language. jq is, in fact, [Turing-complete](https://github.com/MakeNowJust/bf.jq) (someone wrote a Brainfuck interpreter in it, if you need convincing). The design I started with could not stretch to cover any of it.
+
+This post is about how the interpreter evolved to handle those control-flow patterns, and the part OCaml's effect system played in it.
 
 ## What makes jq a real language
 
-Most jq expressions are **generators**: they can produce multiple outputs from a single input.
+Most jq expressions are **generators**: a single input can produce multiple outputs. That one property, described in the [jq manual](https://jqlang.org/manual/), shapes the entire interpreter.
 
 ```bash
 query-json '.users[]' '{"users": ["Alice", "Bob", "Charlie"]}'
@@ -28,22 +30,22 @@ query-json '.users[]' '{"users": ["Alice", "Bob", "Charlie"]}'
 # "Charlie"
 ```
 
-The `.users[]` expression iterates over the array and produces three separate results. These results flow downstream through pipes. This is fundamental to how jq works: every expression is potentially a generator.
+The `.users[]` expression iterates over the array and produces three separate results, and those results flow downstream through any pipe that follows. Every expression is potentially a generator.
 
-And there's more. `.[]` iterates over arrays, producing one output per element. `empty` produces zero outputs, and `select(.age > 30)` drops values that don't match. `label-break` exits a `foreach` early. `halt` and `halt_error` terminate execution immediately with an exit code. `error("message")` raises a user-facing error caught by `try/catch`.
+There is more. `.[]` iterates over an array, producing one output per element. `empty` produces zero outputs. `select(.age > 30)` drops values that do not match. The `label`/`break` construct exits a `foreach` early. `halt` and `halt_error` terminate execution immediately with an exit code. `error("message")` raises a user-facing error that `try/catch` can catch.
 
-These aren't features bolted onto a query language. They're control flow primitives. And they require an interpreter that can do more than "call a function, get a value back."
+These are not features bolted onto a query language. They are control-flow primitives.
 
 ## The simple interpreter
 
-The first version compiled a query string into an expression, then ran it against a JSON value:
+The first version compiled a query string into an expression, then ran that expression against a JSON value:
 
 ```ocaml
 val compile : string -> (expression, string) result
-val interpreter : expression -> Json.t -> (Json.t list, string) result
+val interpreter : expression -> Json.t -> (Json.t, string) result
 ```
 
-`compile` parses and validates the query. `interpreter` evaluates it against the input and returns either a list of results or an error message.
+`compile` parses the query string into an expression and validates it. `interpreter` evaluates that expression against the input and returns either a single result or an error message.
 
 The interpreter itself was a recursive function that pattern-matched on the expression:
 
@@ -63,13 +65,13 @@ let rec interpreter expression json =
   (* ... *)
 ```
 
-This worked fine for the basics. Field access, pipes, simple filters: all straightforward. Each expression takes a JSON value, does its thing, and returns `Ok result` or `Error message`. Pipe runs the left side, checks for errors, feeds the result into the right side.
+This worked for the basics. Field access, pipes, simple filters: each expression takes a JSON value, does its work, and returns `Ok result` or `Error message`. `Pipe` runs the left side, and if it succeeds, feeds that one result into the right side. It worked because every expression here produces exactly one value, which is the assumption the rest of jq is about to break.
 
 ## Where it breaks
 
-The trouble starts when you try to implement real language features on top of this model.
+Control-flow primitives like these need an interpreter that can do more than call a function and get a value back. The simple model starts to crack the moment you implement them on top of it.
 
-**Generators.** jq expressions can produce multiple values, not just one. The `.users[]` expression yields three results from a single input. With the old model, every function returns `(Json.t list, string) result`, which means `pipe` has to collect all results from the left side into a list, then iterate over that list and run the right side for each element, collecting all of those results into another list:
+**Generators.** The simple interpreter gives every expression one slot to return a value, and a generator needs more than one. The obvious fix is to widen that slot to a list, so the return type becomes `(Json.t list, string) result`. Now `pipe` has to collect every result from the left side into a list, then iterate over that list and run the right side for each element, collecting all of those results into another list:
 
 ```ocaml
 | Pipe (left, right) -> (
@@ -84,9 +86,9 @@ The trouble starts when you try to implement real language features on top of th
     Ok all_results)
 ```
 
-Everything is materialized eagerly. There's no way to stream values from one stage to the next, no way for `limit(2; .users[])` to stop after two results without evaluating all of them first.
+Everything is materialized eagerly. There is no way to stream values from one stage to the next, and no way for `limit(2; .users[])` to stop after two results without evaluating all of them first.
 
-**Error handling.** Now try adding `try/catch`. You need every function between the error site and the catch handler to propagate the error. `pipe` has to check for it. `comma` has to check for it. Every combinator in between has to thread the `result` type through, even when they don't care about errors at all:
+**Error handling.** Now add `try/catch`. Every function between the error site and the catch handler has to propagate the error. `pipe` has to check for it. `comma` has to check for it. Every combinator in between has to thread the `result` type through, even the ones that do not care about errors at all:
 
 ```ocaml
 | Comma (left, right) -> (
@@ -98,27 +100,25 @@ Everything is materialized eagerly. There's no way to stream values from one sta
     | Ok right_results -> Ok (left_results @ right_results)))
 ```
 
-The error plumbing dominates every case. And when you want to add `try/catch` that _swallows_ certain errors, or `optional` that catches errors and returns `null` instead, the `result` type isn't enough. You need to distinguish between "user error that `try/catch` should handle" and "runtime error that should propagate." The type grows, and every intermediate function has to pattern-match on the distinction.
+The error plumbing dominates every case. And once you want `try/catch` that _swallows_ certain errors, or `optional` that catches an error and returns `null` instead, the bare `result` type is not enough on its own. You have to distinguish a user error that `try/catch` should handle from a runtime error that should propagate. The type grows another distinction, and every intermediate function has to pattern-match on it.
 
-**Early exit.** `break` inside a loop needs to jump out of the current iteration and land at the loop boundary. With explicit result types, you'd add another variant to the return type (something like `| Break_signal`), and every function between the break site and the loop handler has to check for it and forward it. The pattern of "check result, propagate if needed, otherwise continue" spreads through every single interpreter case.
+**Early exit.** `break` inside a loop has to jump out of the current iteration and land at the loop boundary. With explicit result types, you add yet another variant to the return type, something like `| Break_signal`, and every function between the break site and the loop handler has to check for it and forward it. The pattern of check the result, propagate if needed, otherwise continue spreads into every single interpreter case.
 
-Each new control-flow feature adds another channel that every intermediate function must participate in. The interpreter becomes less about evaluating expressions and more about threading control-flow signals through layers of plumbing.
+Each new control-flow feature adds another variant to the return type, and every intermediate function has to handle it and forward it. The interpreter becomes less about evaluating expressions and more about threading control-flow signals through layers of plumbing. The fix is to stop threading those signals through return values at all.
 
 ## Effects, in plain words
 
-If you've used `try/catch`, you already understand the core idea.
+`try/catch` is the shortest path into effects. When you `throw` an error, execution jumps out of the current function, skips every intermediate frame, and lands at the matching `catch` block somewhere up the call stack. Nothing in between has to take part.
 
-When you `throw` an error, execution jumps out of the current function, skipping all the intermediate code, until it reaches a matching `catch` block somewhere up the call stack. The functions in between don't need to know about errors at all: they don't pass error codes, they don't check return values. The error just propagates automatically.
-
-Dan Abramov wrote a [fantastic explanation](https://overreacted.io/algebraic-effects-for-the-rest-of-us/) of algebraic effects using this exact analogy. The key insight is:
+Dan Abramov wrote a [fantastic explanation](https://overreacted.io/algebraic-effects-for-the-rest-of-us/) of algebraic effects built on exactly this analogy:
 
 > Things in the middle don't need to concern themselves with error handling... Unlike error codes, with `try / catch`, you don't have to manually pass errors through every intermediate layer.
 
-Effects work the same way, but more general. Instead of only throwing errors, you can perform _any_ kind of signal. And the crucial difference: **the handler can resume execution** where the effect was performed.
+Effects work the same way, with one generalization. Instead of only throwing errors, you can perform _any_ kind of signal. And here is the difference that matters: **the handler can resume execution** at the point where the effect was performed.
 
-Think of it as a resumable `throw`. You perform an effect, control jumps to the handler, the handler does something (maybe collects a value, maybe checks a condition), and then it can choose to jump _back_ and continue where you left off.
+Think of it as a resumable `throw`. You perform an effect, control jumps to the handler, the handler does its work (collect a value, check a condition, count something), and then it can choose to jump _back_ and continue where you left off.
 
-In OCaml 5, you declare effects as extensible variant types and perform them with `Effect.perform`:
+OCaml 5 added an [effect system](https://ocaml.org/manual/5.4/effects.html): you declare effects as extensible variant types and perform them with `Effect.perform`.
 
 ```ocaml
 type _ Effect.t +=
@@ -128,11 +128,11 @@ type _ Effect.t +=
   | User_error : Json.t -> unit Effect.t
 ```
 
-These four effects model all of the interpreter's control flow: `Yield` produces results, `Break` stops loops, `Halt` terminates the program, and `User_error` raises catchable errors. The central `interp` function performs one of these effects, nearby handlers catch only what they care about (`Yield` in `pipe`, `User_error` in `try/catch`), unhandled effects bubble to outer handlers, and the top-level `execute` handler is the final boundary.
+These four effects carry the control flow that moves between expressions: `Yield` produces a result, `Break` stops a loop, `Halt` terminates the program, and `User_error` raises a catchable error. Each one is a resumable signal. The interpreter performs it, a handler decides what to do with it, and, for every effect except one, execution picks up where it left off.
 
 ## Rebuilding the interpreter with effects
 
-The interpreter is now a single recursive function called `interp`. It takes a context, an AST node, and a JSON value. Its return type is `unit`: it doesn't return JSON values at all. Instead, when it wants to produce a result, it performs `Yield`. When it needs to gather results, it calls `collect`. When it wants to stop execution, it performs `Break` or `Halt`. When something goes wrong, it performs `User_error`.
+The interpreter is now a single recursive function called `interp`. It takes a context, an AST node, and a JSON value, and its return type is `unit`: it does not return JSON values at all. Everything the old interpreter expressed through return values, producing a result, stopping, failing, `interp` now expresses by performing an effect.
 
 ```ocaml
 let rec interp ~ctx expression json : unit =
@@ -154,19 +154,19 @@ let rec interp ~ctx expression json : unit =
   (* ... hundreds more cases ... *)
 ```
 
-Notice what's _not_ here: no `result` types, no error propagation, no checking return values. Each case does its thing and moves on. The control flow lives in the handlers.
+Notice what is _not_ here: no `result` types, no error propagation, no checking return values. Each case does its work and moves on. The control flow lives in the handlers, and the sections below walk through them one construct at a time.
 
 ### Pipe and Yield
 
-Every time the interpreter wants to produce a result, it calls:
+Every time the interpreter wants to produce a result, it calls `yield`:
 
 ```ocaml
 let yield v = Effect.perform (Yield v)
 ```
 
-This doesn't return the value to a caller. It _performs_ the Yield effect, which suspends execution and hands the value to whichever handler is wrapping the current computation.
+This does not return the value to a caller. It _performs_ the `Yield` effect, which suspends execution and hands the value to whichever handler is wrapping the current computation.
 
-The simplest handler is `run_and_collect_results`, which catches every `Yield` and accumulates values into a list:
+The simplest handler is `run_and_collect_results`, which catches every `Yield` and accumulates the values into a list:
 
 ```ocaml
 let run_and_collect_results fn =
@@ -179,18 +179,18 @@ let run_and_collect_results fn =
   List.rev !acc
 ```
 
-When a `Yield` is caught, the handler gets two things: the yielded value `v` and a **continuation** `k`. The continuation is the rest of the computation, everything that would have happened after the `yield` call. By calling `Effect.Deep.continue k ()`, the handler resumes execution right where it left off. The interpreter wraps this in a function called `collect`:
+When a `Yield` is caught, the handler receives two things: the yielded value `v` and a **continuation** `k`. The continuation is the rest of the computation, everything that would have run after the `yield` call. Calling `Effect.Deep.continue k ()` resumes execution right where it left off. The interpreter wraps this handler in a function called `collect`:
 
 ```ocaml
 and collect ~ctx expr json =
   run_and_collect_results (fun () -> interp ~ctx expr json)
 ```
 
-Consider what happens when you write `[.users[] | select(.active) | .name]` in a query. The `.users[]` iterates over the array, `select(.active)` drops the ones that don't match, `.name` extracts a field, and the surrounding `[ ]` collects all surviving results into a new array. The interpreter calls `collect`, which runs `interp` on the inner pipeline. Each surviving name yields one by one, and `collect` gathers them all into a list.
+Consider what happens with `[.users[] | select(.active) | .name]`. The `.users[]` iterates over the array, `select(.active)` drops the inactive ones, `.name` extracts a field, and the surrounding `[ ]` collects every surviving result into a new array. The interpreter calls `collect`, which runs `interp` on the inner pipeline; each surviving name yields one at a time, and `collect` gathers them into a list.
 
-If you're not familiar with this syntax, try it yourself in the [query-json playground](https://query-json.pages.dev).
+If that syntax is unfamiliar, try it in the [query-json playground](https://query-json.pages.dev).
 
-Pipes use the same mechanism. The expression `a | b` means "run `a`, and for each result it produces, run `b`":
+Pipes use the same `Yield`-and-continue mechanism. The expression `a | b` means run `a`, and for each result it produces, run `b`:
 
 ```ocaml
 and pipe ~ctx left right json =
@@ -199,7 +199,7 @@ and pipe ~ctx left right json =
     ~then_:(fun json -> interp ~ctx right json)
 ```
 
-`on_yield` is a helper that installs a Yield handler:
+`on_yield` installs a `Yield` handler:
 
 ```ocaml
 let on_yield fn ~then_ =
@@ -210,11 +210,11 @@ let on_yield fn ~then_ =
     Effect.Deep.continue k ()
 ```
 
-Each time the left side yields a value, the handler intercepts it and runs the right side with that value as input. Then it resumes the left side to get the next value. The right side might itself yield multiple values, and those propagate up to whatever handler is above. This means `.users[] | .name` naturally does the right thing: `.users[]` yields each user object, and for each one, `.name` yields the name field. No explicit loops, no intermediate lists.
+Each time the left side yields a value, the handler intercepts it, runs the right side with that value as input, then resumes the left side to get the next value. The right side may itself yield multiple values, and those propagate up to whatever handler sits above. So `.users[] | .name` does the right thing on its own: `.users[]` yields each user object, and for each one `.name` yields its name field. No explicit loops, no intermediate lists.
 
 ### Optional
 
-`try-catch` with no catch handler (written `expr?` in jq) swallows errors and produces nothing. With effects, this is a thin wrapper:
+`try/catch` with no catch handler, written `expr?` in jq, swallows errors. In query-json, the implementation catches the error and yields `null` in its place. With effects, it is a thin wrapper:
 
 ```ocaml
 | Optional expr ->
@@ -223,7 +223,7 @@ Each time the left side yields a value, the handler intercepts it and runs the r
     ~on_fail:(fun () -> yield `Null)
 ```
 
-`swallow_errors` installs an effect handler that intercepts `User_error` and `Runtime_error.Fail`, discards the continuation, and calls `on_fail` instead. `Yield` effects pass through untouched. This is the first sign of composability: the handler only catches what it cares about.
+`swallow_errors` installs an effect handler that intercepts errors, discards the continuation, and calls `on_fail` instead. Two kinds of error reach it: the `User_error` effect, and `Runtime_error.Fail`, a fifth effect that the interpreter performs for internal failures like a type mismatch or a missing key. `Runtime_error.Fail` is declared on its own, in the interpreter's `Runtime_error` module, which is why it does not appear in the four-effect block earlier. The handler treats both the same; the distinction only matters at the point each one is performed. `Yield` effects are not its concern, so they pass straight through to whatever handler sits outside it.
 
 ### Try/catch and User_error
 
@@ -235,7 +235,7 @@ let user_error value =
   assert false
 ```
 
-The `assert false` is dead code: `User_error` is never resumed, so execution never reaches it. It exists to satisfy the type checker.
+The `assert false` is dead code. `User_error` is never resumed, so execution never reaches that line; it exists only to satisfy the type checker.
 
 User errors interact with `try/catch`:
 
@@ -267,18 +267,18 @@ and try_catch ~ctx expr handler finally_expr json =
   (* ... *)
 ```
 
-`catch_errors` installs an effect handler that intercepts `User_error` and `Runtime_error.Fail`, discards the continuation, and runs the catch handler instead. Effects it doesn't recognize (like `Yield` or `Break`) pass through transparently, bubbling up to the next handler:
+Where `swallow_errors` discards an error silently, `catch_errors` routes it to a recovery expression. It intercepts the same two error kinds, `User_error` and `Runtime_error.Fail`, discards the continuation, and runs the catch handler instead. Effects it does not recognize, such as `Yield` or `Break`, pass through transparently and bubble up to the next handler:
 
 ```bash
 query-json 'try error("boom") catch "caught: " + .message' 'null'
 # "caught: boom"
 ```
 
-This composability is what makes the whole thing work. The `try/catch` handler doesn't need to know about `Yield`. The `pipe` handler doesn't need to know about `User_error`. Each handler does its job and leaves everything else alone.
+This composability is what makes the whole design work. The `try/catch` handler does not need to know about `Yield`. The `pipe` handler does not need to know about `User_error`. Each handler does its job and leaves everything else alone.
 
 ### Limit, Break, and early exit
 
-Some constructs need to stop producing values early. `limit(n; expr)` runs `expr` but only takes the first `n` results:
+Some constructs need to stop producing values early. `limit(n; expr)` runs `expr` but takes only the first `n` results:
 
 ```bash
 query-json 'limit(2; .users[])' '{"users": ["Alice", "Bob", "Charlie"]}'
@@ -286,7 +286,7 @@ query-json 'limit(2; .users[])' '{"users": ["Alice", "Bob", "Charlie"]}'
 # "Bob"
 ```
 
-The implementation installs a Yield handler that can choose _not_ to continue:
+The implementation installs a `Yield` handler that can choose _not_ to continue:
 
 ```ocaml
 and limit ~ctx n expr json =
@@ -300,11 +300,11 @@ and limit ~ctx n expr json =
       Effect.Deep.continue k ())
 ```
 
-When the count reaches `n`, the handler simply doesn't call `continue`. The continuation, and everything it would have done, is discarded. This is the key insight about effects: the handler controls whether to resume.
+When the count reaches `n`, the handler simply does not call `continue`. The continuation, and everything it would have done, is discarded. This is the point of effects for control flow: the handler decides whether to resume.
 
-You could implement `limit` with exceptions: throw a `Limit_reached` exception and catch it at the right level. But consider what that does to `pipe`. In `a | b`, the left side is a generator that yields values one at a time. With effects, `limit` simply stops calling `continue` and the generator disappears. With exceptions, you'd need to throw _through_ the pipe handler, which is also trying to catch yields, and somehow not confuse "I'm done producing values" with "something went wrong." Every intermediate handler becomes responsible for re-raising exceptions it doesn't own. Effects avoid this entirely because each effect type is distinct: a `Break` passes transparently through a `Yield` handler without any explicit forwarding.
+You could implement `limit` with exceptions instead: throw a `Limit_reached` exception and catch it at the right level. But that fights the `pipe` handler. In `a | b` the left side yields values one at a time, so a `Limit_reached` exception has to travel _through_ the `Yield` handler that `pipe` installed, and that handler must not mistake "I am done producing values" for "something went wrong." Effects sidestep the problem: `limit` simply stops calling `continue`, and because each effect type is distinct, a `Break` passes through a `Yield` handler untouched, the same isolation you saw with `try/catch`.
 
-`Break` works the same way but at a higher level. It's used inside loops to exit early, and the top-level `execute` function catches unhandled `Break` effects (since `break` outside a loop is meaningless):
+`Break` works the same way at a higher level. It exits a loop early, and the top-level `execute` function catches any unhandled `Break` effect, since `break` outside a loop is meaningless:
 
 ```ocaml
 let execute ~colorize ~verbose ?(env = []) expr json =
@@ -322,38 +322,30 @@ let execute ~colorize ~verbose ?(env = []) expr json =
 
 ### Halt
 
-`halt` terminates the entire program with an exit code. It's the one effect that never resumes:
+`halt` terminates the entire program with an exit code. It is the one effect that never resumes:
 
 ```ocaml
 let halt ?(code = 0) () = Effect.perform (Halt code)
 ```
 
-The top-level handler catches it and returns `Halt exit_code`, ignoring the continuation entirely. This _could_ be an exception (it never resumes, it just unwinds), but keeping it as an effect means `execute` handles all four control-flow channels in one uniform `match` expression.
+The top-level handler catches it and terminates, ignoring the continuation entirely. `halt` could have been an exception, since it never resumes and only unwinds. Keeping `halt` as an effect means the top-level `execute` handler deals with `Break` and `Halt` side by side, in the same uniform `match` expression.
 
-## Why effects here
+## Where effects earn their place
 
-I don't think effects are universally better than exceptions or `result`. They are useful _here_ because jq pipelines combine generators, early exits, and catchable user errors in deeply nested interpreter paths.
+I do not think effects are universally better than exceptions or `result`. They earn their place _here_ for a specific reason: a jq interpreter combines generators, early exits, and catchable user errors along deeply nested evaluation paths, and OCaml's effects compose all three without the plumbing.
 
-| Concern | Effects | Exceptions | `result`/sum-return plumbing |
+| Concern | Effects | Exceptions | `result` / sum-return plumbing |
 | --- | --- | --- | --- |
-| Pipeline ergonomics (`a \| b`) | `Yield` composes naturally via handlers | Needs careful re-raise discipline around intermediate handlers | Return types balloon quickly and spread through many cases |
-| Selective handling | Handle `Yield` without touching `Break`/`Halt`/`User_error` | Usually one channel unless you build custom hierarchies | Possible, but requires explicit branching in many layers |
-| Resume semantics | Built-in (`Effect.Deep.continue`) | Not resumable | Manual threading only |
-| Error/control-flow distinction | Separate effect constructors | Easy to conflate early-stop vs real error | Explicit but noisy in interpreter glue |
-| Debuggability | Clear once handlers are centralized | Familiar tools, but mixed intent in one mechanism | Explicit at call sites, but hard to read globally |
+| Pipeline ergonomics (`a \| b`) | `Yield` composes naturally through handlers | Needs careful re-raise discipline around intermediate handlers | Return types grow and thread through many cases |
+| Selective handling | Handle `Yield` without touching `Break`, `Halt`, or `User_error` | Usually one channel unless you build a custom hierarchy | Possible, but requires explicit pattern-matching at every propagating layer |
+| Resume semantics | Built in, through `Effect.Deep.continue` | Not resumable | Manual threading only |
+| Error vs control-flow distinction | Separate effect constructors | Easy to conflate an early stop with a real error | Explicit, but verbose in interpreter glue |
+| Debuggability | Clear once the handlers are centralized | Familiar tooling, but mixed intent in one mechanism | Explicit at each call site, hard to read as a whole |
 
-## Where effects actually matter
+Even here, effects are not the whole interpreter. They are load-bearing for roughly 20% of it: `pipe`, `comma`, `select`, `limit`, `try/catch`, `alternative`, the compositional glue that connects expressions. That 20% is exactly the control flow. It is where the generator model matters, where values flow lazily from one stage to the next, and where early termination and error propagation have to cross handler boundaries cleanly.
 
-Most of the interpreter (`map`, `sort_by`, `group_by`, `keys`, math operations) eagerly collects results into lists via `collect` and then works on those lists directly. Those functions could return `Json.t list` and be fine.
+The other 80%, functions like `map`, `sort_by`, `group_by`, `keys`, and the math operations, is not control flow at all. Each of those calls `collect`, gets a list, and works on the list directly. They could return a plain `Json.t list` and be fine. The refactor to effects barely touched them. What effects changed was the connective tissue between those functions, the part that was painful to implement with explicit result types, and that is what justified the complexity.
 
-Effects are load-bearing for about 20% of the interpreter: `pipe`, `comma`, `select`, `limit`, `try/catch`, `alternative`, the compositional glue that connects expressions. That's where the generator model matters, where values flow lazily from one stage to the next, where early termination and error propagation need to cross boundaries cleanly.
+Performance was one of the first questions I had after the refactor. On the [published benchmark set](https://github.com/davesnx/query-json/blob/main/benchmarks/README.md) (query-json `0.5.52` against jq `1.8.1`), query-json is generally faster, with reported speedups between roughly `1.5x` and `4.5x` depending on the operation and the file size. That does **not** prove effects are the reason for the wins. The same benchmark report points to native compilation, parser and runtime choices, and architecture differences. The honest takeaway is narrower: moving the control-flow glue to effects did not cost performance.
 
-But that 20% is the hard part. It's the part that was painful to implement with explicit result types, the part where every intermediate function had to participate in the plumbing. The other 80% was always straightforward: call `collect`, get a list, work on the list. Effects didn't change those functions much. They changed the connective tissue between them, and that made all the difference.
-
-## Performance
-
-Performance was one of the first questions I had after this refactor. On the published benchmark set (query-json `0.5.52` vs jq `1.8.1`), query-json is generally faster, with reported speedups between roughly `1.5x` and `4.5x` depending on operation and file size. This does **not** prove effects are the reason for all wins: the benchmark report also points to native compilation, parser/runtime choices, and architecture differences. The practical takeaway is narrower: moving control-flow glue to effects did not block strong performance in real workloads.
-
-If you want to inspect the implementation, [query-json is on GitHub](https://github.com/davesnx/query-json) and the interpreter lives in [`source/Interpreter.ml`](https://github.com/davesnx/query-json/blob/main/source/Interpreter.ml).
-
-If you want to try the language quickly, open the [query-json playground](https://query-json.pages.dev), run a few generator-heavy queries (`.[]`, `limit`, `try/catch`), then read the effect handlers side by side with those queries. That makes the control-flow model click fast.
+The full implementation is [on GitHub](https://github.com/davesnx/query-json), and the interpreter lives in [`source/Interpreter.ml`](https://github.com/davesnx/query-json/blob/main/source/Interpreter.ml). Read the handlers next to the queries they run, and the control-flow model falls into place quickly.


### PR DESCRIPTION
Hi there.

**Your piece was already in good shape**. Using try/catch as the on-ramp to effects is the right instinct, the code excerpts are well chosen, and the honesty in the back half, scoping effects to about 20% of the interpreter and keeping the performance section from over-claiming, is a real strength. Most of what I did was tighten things around that core rather than rework it. 

Here is what I changed, and why.

- The jq-notation primer. You left a note in the intro flagging that readers who do not know jq might hit the first code block cold. I agreed, so I took a first pass at it: three short lines on what a jq filter is, what .name and .users[] do, and how the pipe composes. Treat my wording as a starting point. You know your audience better than I do.
- The ending. The original closed with three sections (Why effects here, Where effects actually matter, Performance). Each one holds up alone, but read back to back, they make the article feel like it stopped three times. I merged them into one closing section, "Where Effects Earn Their Place," so the trade-off table, the 20% point, and the performance numbers build to a single landing. This one is your call. If you prefer them separate, putting them back is easy.
- The early interpreter's type signature. I want to explain this one carefully, because it is a sequencing decision more than a correction. In "The Simple Interpreter," the early signature returned (Json.t list, string) result. The "Where It Breaks" section then makes its argument by saying that supporting generators is what pushes you onto a list type. If the first, simple version already returned a list, that turn loses its setup. So I set the early signature to a single value, (Json.t, string) result, and let the list type appear later as the thing generators force on you. It reads as a clean progression: single value, then list, then effects. I also looked at the early query-json commits, and the first versions did return a single value, so the single-value framing matches the real history too. Nothing was wrong in the original. It was a narrative-sequencing thing.
- Runtime_error.Fail. It shows up in two of the handler snippets (Optional and Try/catch), but the draft never quite introduces it, which can leave a reader who was just told there are "four effects" wondering where the fifth name came from. I added a short explanation: it is a fifth effect, declared on its own in the interpreter's Runtime_error module rather than in the main block, which is why it is not part of that four-effect declaration. It is an easy thing to overlook, since it lives in a separate module, a bit apart from the headline four. It reads to me as a clean parallel to User_error, but you know the code. If I have any details of its behavior wrong, tell me and I will fix it.
- The title. I moved the subtitle to active voice and trimmed "all control flow" to "control flow." The body is careful to say effects carry roughly 20% of the interpreter, so "all" oversold it a little. The hook, OCaml effects for a jq interpreter, holds up without it. Happy to put it back if you feel differently.

A few smaller things, the sort that are easy to miss while writing. The Optional section described expr? as producing "nothing," while the code just below it yields null, so I aligned the prose to the code. I made the simple-interpreter type signature and its Pipe snippet agree with each other, clarified the "channel" metaphor where it first appears, untangled a couple of sentences that leaned on stacked pronouns, and smoothed the lead-in from the rebuild overview into the handler walkthrough. I added a few inline links (the jq manual, the OCaml effects manual, the benchmark README) so the factual claims are sourced, but kept that light. A deep dive should not read like a paper.

I left your voice alone on purpose. The first person, the opinion ("I don't think effects are universally better"), the honest caveats, the minimal code excerpts with the "hundreds more cases" elisions. Those are strengths, and I did not want to sand them down.

A few questions before I take this further:

- The ending: are you happy with the three closing sections combined into one, or would you rather keep them separate?
- The intro primer: does my jq-notation explanation match how you would introduce it, or would you like to rewrite that part in your own words?