### PR TITLE
Polish published blog posts

### DIFF
--- a/src/content/posts/better-yarn-npm-run.mdx
+++ b/src/content/posts/better-yarn-npm-run.mdx
@@ -10,13 +10,13 @@ tags:
   - "npm"
 ---
 
-In a Node environment or a project with a package.json, It's very common to have a field `"scripts"` inside the **package.json** which stores and lists the scripts available to build, test and run the project.
+In a Node environment or a project with a package.json, it's very common to have a `"scripts"` field in **package.json**. It lists the scripts available to build, test, and run the project.
 
-In order to see which scripts are available in the project without opening the package.json with an editor, `yarn` and `npm` have a command that lists them: `yarn run` or `npm run`.
+To see which scripts are available without opening package.json in an editor, `yarn` and `npm` provide commands that list them: `yarn run` and `npm run`.
 
-Which is a prompt that allows you to write which command you want to run or list them, depend if you are using npm or yarn.
+Depending on whether you use npm or yarn, the command either lists the scripts or opens a prompt where you can enter the command you want to run.
 
-This is the output in a recently created expo app:
+This is the output from a recently created expo app:
 
 ```bash
 yarn run v1.22.4
@@ -34,13 +34,13 @@ info Project commands
 question Which command would you like to run?:
 ```
 
-It's very handy and allows you to not spend energy trying to remember those and have a fast lookup, but it's **very slow** (around 250ms!) since needs to start a node process, parse the json file and output something to stdin and the **UX can be better** since it forces you to type the command again.
+It's very handy. You get a fast lookup instead of spending energy trying to remember the commands. But it's **very slow** (around 250ms!) because it needs to start a node process, parse the json file, and send output to stdin. The **UX could be better**, too, because it forces you to type the command again.
 
-I was a little frustrated by it and I created a small bash script that solves it, it's aliased to `run` in my local enviroment, take a look how it works:
+I was a little frustrated, so I created a small bash script to solve it. It's aliased to `run` in my local environment, and it works like this:
 
 ![yarn-run.gif](/images/yarn-run.gif)
 
-It uses [fzf](https://github.com/junegunn/fzf) to filter the commands available and allows a fast search for them. If you don't know what's fzf, I can't recommend enough taking a look at it. fzf stands for _fuzzy finder_ and it's used by when hit `CTRL+R` to navigate the bash history and It's commonly used to navigate between files in your editor.
+It uses [fzf](https://github.com/junegunn/fzf) to filter the available commands and search them quickly. If you don't know what fzf is, I can't recommend taking a look at it enough. fzf stands for *fuzzy finder*. With fzf's shell integration enabled, I use `CTRL+R` to navigate my shell history; fzf is also commonly used to navigate files in an editor.
 
 ![fzf.gif](/images/fzf.gif)
 
@@ -62,19 +62,19 @@ else
 fi
 ```
 
-This can be intimidating at first so in order to understand it better, let's break it down to explain a little what each command does.
+This can be intimidating at first, so let's break it down and explain what each command does.
 
-The first interesting bit is to preview the content of `package.json` and make it appear on a `fzf` menu.
+The first interesting bit previews the content of `package.json` in an `fzf` menu.
 
 ```
 cat package.json | jq .scripts | sed '1d;$d'
 ```
 
-`cat package.json` prints the content of the package.json
+`cat package.json` prints the content of package.json.
 
-`jq .scripts` parses the json and selects only "scripts"
+`jq .scripts` parses the json and selects only `"scripts"`.
 
-`sed '1d;$d'` removes the first and the last line
+`sed '1d;$d'` removes the first and last lines.
 
 ```json
 "predeploy": "yarn build",
@@ -86,19 +86,19 @@ cat package.json | jq .scripts | sed '1d;$d'
 "serve": "gatsby serve",
 ```
 
-This output gets passed to [fzf](https://github.com/junegunn/fzf), which creates the floating menu, and once you select one of the rows, the `$script` value is set to `"start": "npm run develop"` and finally you are able to get the command name `"start"`, saves that command to the history and finaly runs `"yarn run start"`.
+This output gets passed to [fzf](https://github.com/junegunn/fzf), which creates the floating menu. Once you select a row, the `$script` value is set to `"start": "npm run develop"`. The script then gets the command name `"start"`, saves that command to the history, and finally runs `"yarn run start"`.
 
-> I appended `yarn run` instead of `yarn start` which is also valid, to avoid shadowing any binary.
+> I appended `yarn run` instead of `yarn start`, which is also valid, to avoid shadowing any binary.
 
 ## Custom
 
-This script lives under my [dotfiles repo](https://github.com/davesnx/setup/blob/master/bin/run), which is an easy way to install and setup your enviroment each time you change laptops.
+This script lives in my [dotfiles repo](https://github.com/davesnx/setup/blob/master/bin/run), which is an easy way to install and set up your environment each time you change laptops.
 
-Feel free to change this script to use `npm` or do any sort of change, I found playing with my terminal very rewarding, getting to learn deeper about the tools that I used everyday, allowed me to do stuff that I wasn't capable before and having those small performance boosts made my life a little easier. I will keep sharing more as they pop in my head.
+Feel free to change this script to use `npm` or make any other changes. I've found playing with my terminal very rewarding. Learning more about the tools I use every day has let me do things I couldn't do before, and those small performance boosts have made my life a little easier. I'll keep sharing more as they pop into my head.
 
 ### Resources
 
-- For an introduction to the fzf, see this [blog post](https://www.freecodecamp.org/news/fzf-a-command-line-fuzzy-finder-missing-demo-a7de312403ff)
-- My personal setup [davesnx/setup](https://github.com/davesnx/setup) using zsh
-- If you aren't familiar with the dotfiles [this](https://www.freecodecamp.org/news/dive-into-dotfiles-part-1-e4eb1003cff6/) would give a little clarity
-- For the spanish speakers I found this [course](https://pro.codely.tv/library/terminal-zsh/about) amazing
+- For an introduction to fzf, see this [blog post](https://www.freecodecamp.org/news/fzf-a-command-line-fuzzy-finder-missing-demo-a7de312403ff)
+- My personal setup, [davesnx/setup](https://github.com/davesnx/setup), uses zsh
+- If you aren't familiar with dotfiles, [this](https://www.freecodecamp.org/news/dive-into-dotfiles-part-1-e4eb1003cff6/) should provide a little clarity
+- For Spanish speakers, I found this [course](https://pro.codely.tv/library/terminal-zsh/about) amazing

--- a/src/content/posts/cram-tests-a-hidden-gem-of-dune.mdx
+++ b/src/content/posts/cram-tests-a-hidden-gem-of-dune.mdx
@@ -10,19 +10,17 @@ tags:
   - "testing"
 ---
 
-I'm a strong advocate of unit tests, I can confidently say that it has saved me from introducing regressions countless times. Today I want to share one of the hidden gems of OCaml and their testing story with dune, cram tests.
+I'm a strong advocate of unit tests. I can confidently say they've saved me from introducing regressions countless times. Today I want to share one of the hidden gems in OCaml's testing story with dune: cram tests.
 
-Cram tests, in essence, are snapshots of interactive shell sessions. They provide a versatile framework for testing OCaml projects, but not only OCaml, they can be used for any CLI.
+Cram tests are snapshots of interactive shell sessions. They offer a versatile framework for testing OCaml projects, and you can use them for any CLI.
 
-I’m surprised why this pattern is not more common outside of (the small) world of OCaml, since they come from Python ([bitheap.org/cram](https://bitheap.org/cram)) and there are implementations in Go (https://github.com/mgeisler/cram) and other languages. Probably because it didn’t reach to JavaScript world (??) and they are a bit old.
-
-Regardless, let’s dive in
+I'm surprised this pattern isn't more common outside the (small) world of OCaml. It came from Python ([bitheap.org/cram](https://bitheap.org/cram)), and implementations exist in Go (https://github.com/mgeisler/cram) and other languages. Maybe cram tests never reached the JavaScript world (??), and they're a bit old.
 
 ### Cram test file format
 
-Those test files contain both the execution of the CLI invocations followed by the expected output either from stdout or stderr. The test runner, in this case dune, will run those invocations and diff with the expected output.
+A cram test file contains CLI invocations followed by the expected output from either stdout or stderr. The test runner, dune in this case, runs those invocations and diffs the actual output against the expected output.
 
-Let’s check the syntax with an example:
+For example:
 
 ```cram
 Here there is just a coment about this test, since there is no space at the start
@@ -39,27 +37,27 @@ The command `cat data.txt` gets diffed against the next line `  This command run
 ` from this file, and that's the first beauty of cram tests.
 ```
 
-To define the syntax as rules:
+The syntax has three rules:
 
-- Text and no indentation, are comments
-- Lines with a dollar sign and indentation, run in the shell
-- Lines after a shell, indentation and prefixed by `>` contains the expected output (either stdout or stderr)
+- Text without indentation is a comment
+- Indented lines with a dollar sign run in the shell
+- Lines after a shell command, indented and prefixed by `>`, contain the expected output from either stdout or stderr
 
 ![cram test editor screenshot](/images/cram.png)
 
-This is a screenshot of my editor, showcasing the syntax highlighting and a real `.t` file
+This screenshot shows the syntax highlighting in my editor and a real `.t` file.
 
 ## Dune integrates perfectly with cram tests
 
-dune supports cram tests out of the box and integrates nicely with all your dune test workflow.
+dune supports cram tests out of the box and fits into your existing dune test workflow.
 
-In previous versions of dune, you need to enable them manually. For dune < 3 add `(cram enabled)` in dune-project (might need to create a dune-project file at the root of your project if you don't have one already). If you are using dune > 3, nothing to do, they are already enabled
+With dune < 3, you need to enable them manually. Add `(cram enabled)` to dune-project, and create a dune-project file at the root of your project if you don't already have one. If you are using dune > 3, there is nothing to do because cram tests are already enabled.
 
 ### Your first cram test
 
-If you want to experience the flow of it before using it in a real-world scenario, open your dune project and follow it as a tutorial.
+To experience the workflow before using it in a real-world scenario, open your dune project and follow this tutorial.
 
-Let’s start with the simplest possible test.
+Start with the simplest possible test.
 
 1. Create a file called `simple.t` with:
 
@@ -67,11 +65,11 @@ Let’s start with the simplest possible test.
   $ echo 'lola'
 ```
 
-2. Run the test and let it crash, either
+2. Run the test and let it crash in one of two ways:
 - run the entire “test suite” with **`dune runtest`**
-- or a specific test with their respective alias, since all cram tests are automatically dune aliases: **`dune build @simple —watch`**
+- run a specific test with its respective alias, since all cram tests are automatically dune aliases: **`dune build @simple —watch`**
 
-Output of the execution will be:
+The execution will produce this output:
 
 ```diff
 File "tests/simple.t", line 1, characters 0-0:
@@ -84,38 +82,38 @@ index de6f8c28..ef3231ef 100644
 +  lola
 ```
 
-3. Accept the result as correct. We can update the snapshot with the boring and tedious way, manually or automatically with promotion.
+3. Accept the result as correct. You can update the snapshot the boring and tedious way, either manually or automatically with promotion.
 
-Running **`dune build @simple —auto-promote`** which updates `simple.t` file for you.
+Run **`dune build @simple —auto-promote`** to update the `simple.t` file for you.
 
-To ensure everything works, try running the tests again, which in this case should pass. Run **`dune build @simple`** and the output should be empty. Empty in dune, means very good
+To ensure everything works, run the tests again. In this case, **`dune build @simple`** should pass with empty output. Empty in dune means very good.
 
 ## Organise the cram suite
 
-Directories with `.t` with a `run.t` file inside, are also valid cram tests.
+Directories with `.t` and a `run.t` file inside are also valid cram tests.
 
-Keep all your tests as `.t` files can get out of hand pretty quickly, since some test suites could contain hundreds of tests, and some tests might contain fixtures or any config files
+Keeping all your tests as `.t` files can get out of hand pretty quickly. Some test suites could contain hundreds of tests, and some tests might contain fixtures or config files.
 
 ## Make your executable available under cram tests
 
-You might write a perfect test, only to be greeted with `[ERROR] Program "your_binary" not found!`. This happens because dune doesn't automatically know which executables should be accessible during cram test execution.
+You might write a perfect test only to be greeted with `[ERROR] Program "your_binary" not found!`. This happens because dune doesn't automatically know which executables should be accessible during cram test execution.
 
 There are four ways to expose your executable to cram tests:
 
-- **option A**: add a `public_name` in your executable stanza like `(public_name amazing-binary)`, which makes the executable available to the test suite as `amazing-binary.exe`, and when users install your package, the executable will be under `my-opam-package.amazing-binary`.
-- **option B**: set the executable to be part of the dune installation with the [install stanza](https://dune.readthedocs.io/en/latest/reference/dune/install.html) `(install (section bin) (files amazing-binary.exe))`. Do not confuse dune installation with opam installation, the dune installation offers a way to "copying freshly built artifacts from the workspace to the system", while opam installs opam packages in your opam switch (downloading from opam repositories, building from sources, etc).
-- **option C**: use `(env _ (binaries ../bin/amazing-binary.exe))` to set an executable to be available as a binary: `amazing-binary` will be available to the test suite, and can choose to change which environment will have it. This is useful if you don't want to rely on the exact location of the executable, and don't want to expose the executable to the user. (Thanks to [sim642](https://discuss.ocaml.org/t/ann-cram-tests-a-hidden-gem-of-dune-and-snapshot-tests-for-your-own-ppx/15910/2?u=davesnx) for the tip).
-- **option D**: directly specify the executable as a dependency in your cram test `(deps %{exe:../bin/amazing-binary.exe})`. More info in about the `cram` stanza in the [dune documentation](https://dune.readthedocs.io/en/latest/reference/dune/cram.html).
+- **option A**: Add a `public_name` to your executable stanza, such as `(public_name amazing-binary)`. This makes the executable available to the test suite as `amazing-binary.exe`. When users install your package, the executable will be under `my-opam-package.amazing-binary`.
+- **option B**: Make the executable part of the dune installation with the [install stanza](https://dune.readthedocs.io/en/latest/reference/dune/install.html), `(install (section bin) (files amazing-binary.exe))`. Do not confuse dune installation with opam installation. Dune installation offers a way of "copying freshly built artifacts from the workspace to the system", while opam installs opam packages in your opam switch by downloading them from opam repositories, building from source, and so on.
+- **option C**: Use `(env _ (binaries ../bin/amazing-binary.exe))` to make an executable available as a binary. `amazing-binary` will be available to the test suite, and you can choose which environment will have it. This is useful if you don't want to rely on the executable's exact location or expose it to the user. (Thanks to [sim642](https://discuss.ocaml.org/t/ann-cram-tests-a-hidden-gem-of-dune-and-snapshot-tests-for-your-own-ppx/15910/2?u=davesnx) for the tip).
+- **option D**: Specify the executable directly as a dependency in your cram test with `(deps %{exe:../bin/amazing-binary.exe})`. The [dune documentation](https://dune.readthedocs.io/en/latest/reference/dune/cram.html) has more information about the `cram` stanza.
 
-If you're not sure which to choose, I recommend starting with setting a `public_name` in your executable stanza. It's the most explicit approach and if you are working on a CLI, you will still need a `public_name` to expose it on the opam package.
+If you're not sure which to choose, I recommend starting by setting a `public_name` in your executable stanza. It's the most explicit approach, and if you are working on a CLI, you will still need a `public_name` to expose it on the opam package.
 
 ## What makes a good (cram) test?
 
-Writing effective cram tests requires more than just copying command output, let's see some key principles that will help you write robust and maintainable snapshot tests
+Effective cram tests require more than copying command output. These principles will help you write robust and maintainable snapshot tests.
 
 ### Keep tests hermetic
 
-Your tests should be *hermetic* - meaning they're self-contained and don't depend on external state. Each test should clean up after itself and running it multiple times should produce the same result. For example:
+Your tests should be *hermetic*, meaning they're self-contained and don't depend on external state. Each test should clean up after itself, and running it multiple times should produce the same result. For example:
 
 ```cram
   $ mkdir -p tmp
@@ -129,7 +127,7 @@ Your tests should be *hermetic* - meaning they're self-contained and don't depen
 
 ### Use relative paths and environment variables
 
-One common pitfall is hardcoding absolute paths in your tests. This makes tests brittle and non-portable. Dune provides several environment variables to help write path-independent tests:
+Hardcoding absolute paths is a common pitfall. It makes tests brittle and non-portable. Dune provides several environment variables for writing path-independent tests:
 
 ```cram
 DON'T do this
@@ -146,7 +144,7 @@ Some useful environment variables include:
 - `$PWD`: Current working directory
 - `$DUNE_BUILD_DIR`: Path to dune's build directory
 
-Here's a more complete example showing these variables in action:
+This more complete example shows the variables in action:
 
 ```cram
   $ echo $DUNE_ROOT | grep -o '[^/]*$'
@@ -163,25 +161,25 @@ Test the compiled output
   Hello, World!
 ```
 
-This approach ensures your tests will run consistently across different environments and developer machines. It's especially important if you plan to run these tests in CI or in other developer local envs.
+This approach keeps your tests consistent across different environments and developer machines. It's especially important if you plan to run them in CI or other developers' local environments.
 
 ### Self documenting
 
-A good cram test should explain its purpose and any non-obvious setup, making it easier for others (or yourself in 6 months) to understand what's being tested and why. The comments should focus on the intent behind the test, not just describe the commands being run.
+A good cram test should explain its purpose and any non-obvious setup. This makes it easier for others, or yourself in 6 months, to understand what's being tested and why. Comments should focus on the test's intent rather than describe the commands being run.
 
 ## They are used in the wild
 
-The true testament to cram tests' effectiveness is their adoption by prominent projects in the OCaml ecosystem.
+The adoption of cram tests by prominent projects in the OCaml ecosystem shows their effectiveness.
 
-Dune itself, uses cram tests extensively throughout its codebase - with over 800 tests covering everything from basic builds to complex workspace configurations. They also used cram tests for bug reporting. When users encounter issues, they're encouraged to submit a minimal reproduction case as a cram test. This practice has been so successful that many bug reports in their issue tracker include a `.t` file demonstrating the problem.
+Dune itself uses cram tests extensively throughout its codebase, with over 800 tests covering everything from basic builds to complex workspace configurations. Dune has also used cram tests for bug reporting. When users encounter issues, they're encouraged to submit a minimal reproduction case as a cram test. This practice has been so successful that many bug reports in Dune's issue tracker include a `.t` file demonstrating the problem.
 
-Melange is another great other example of it, where ensures the JavaScript compilation to remain consistent with blackbox tests https://github.com/melange-re/melange/tree/main/test/blackbox-tests.
+Melange is another great example. It uses blackbox tests to ensure that JavaScript compilation remains consistent: https://github.com/melange-re/melange/tree/main/test/blackbox-tests.
 
-As a useful reference, there’s some of my work migrating to cram tests in here:
+For reference, here is some of my work migrating to cram tests:
 
 - **Migrate ReasonML’s tests to cram suite**: https://github.com/reasonml/reason/pull/2694
 - **styled-ppx** contains a few suites of snapshots (mostly ppx transformations): https://github.com/davesnx/styled-ppx/tree/main/packages/ppx/test/snapshot
-- **reason-react-ppx** ensures their ppx generation to be consistent, but also the JavaScript output: https://github.com/reasonml/reason-react/tree/main/ppx/test
+- **reason-react-ppx** keeps its ppx generation and JavaScript output consistent: https://github.com/reasonml/reason-react/tree/main/ppx/test
 
 ## Ending words
 

--- a/src/content/posts/cross-compile-query-json.mdx
+++ b/src/content/posts/cross-compile-query-json.mdx
@@ -13,22 +13,21 @@ tags:
   - "js_of_ocaml"
 ---
 
-[query-json](https://github.com/davesnx/query-json) is a faster and simpler re-implementation of [jq's language](https://github.com/stedolan/jq/wiki/jq-Language-Description) in [Reason](https://reasonml.github.io), compiled to a native binary and to a JavaScript library.
+[query-json](https://github.com/davesnx/query-json) is a faster and simpler re-implementation of [jq's language](https://github.com/stedolan/jq/wiki/jq-Language-Description) in [Reason](https://reasonml.github.io), compiled to a native binary and a JavaScript library.
 
-It's a CLI to run small programs against JSON files, the same idea as [sed](https://www.linode.com/docs/tools-reference/tools/manipulate-text-from-the-command-line-with-sed/) for text. As a web engineer, it's an essential tool while debugging HTTP APIs or exploring big JSON files (like those from AWS Config).
+It's a CLI for running small programs against JSON files, the same idea as [sed](https://www.linode.com/docs/tools-reference/tools/manipulate-text-from-the-command-line-with-sed/) for text. As a web engineer, I find it essential when debugging HTTP APIs or exploring big JSON files, such as those from AWS Config.
 
-I started the project with the goal to create something useful and learn during the process. I was very interested in learning how to write a parser and a compiler using the OCaml stack: [menhir](https://opam.ocaml.org/packages/menhir) and [sedlex](https://github.com/ocaml-community/sedlex), and finally try to compile it to JavaScript.
+I started the project to create something useful and learn along the way. I especially wanted to learn how to write a parser and a compiler with the OCaml stack, using [menhir](https://opam.ocaml.org/packages/menhir) and [sedlex](https://github.com/ocaml-community/sedlex), and then try compiling it to JavaScript.
 
-This post explains the project, how it was made, the decisions I followed, and some reflections.
+I'll explain the project, how I made it, the decisions I followed, and some reflections.
 
 ![](/images/exploded-view.jpg)
 
 ## Why I wanted to learn parsers/compilers
 
-I had a vague idea about the theory, but nothing practical. It was the right time since I had made [styled-ppx](https://github.com/davesnx/styled-ppx), a
-**ppx** (**P**re**P**rocessor E**x**tension) that allows CSS-in-Reason/OCaml. It needs to parse CSS and do some code generation for [bs-emotion](https://github.com/ahrefs/bs-emotion).
+I had a vague idea of the theory but no practical experience. The timing was right because I had made [styled-ppx](https://github.com/davesnx/styled-ppx), a **ppx** (**P**re**P**rocessor E**x**tension) that allows CSS-in-Reason/OCaml. It needs to parse CSS and generate some code for [bs-emotion](https://github.com/ahrefs/bs-emotion).
 
-I asked [@EduardoRFS](https://www.twitch.tv/eduardorfs) for help writing a CSS Parser that supports the entire [CSS3 specification](https://www.w3.org/TR/2001/WD-css3-roadmap-20010523/) and he came up with something. That "something" is a project I want to understand, improve, and maintain over time.
+I asked [@EduardoRFS](https://www.twitch.tv/eduardorfs) for help writing a CSS Parser that supports the entire [CSS3 specification](https://www.w3.org/TR/2001/WD-css3-roadmap-20010523/), and he came up with something. That "something" is a project I want to understand, improve, and maintain over time.
 
 ## How query-json works
 
@@ -38,7 +37,7 @@ query-json ".store.books | filter(.price > 10)" stores.json
 
 This reads `stores.json` and runs the query `".store.books | filter(.price > 10)"` against it.
 
-The query describes a jq program. By running it, it accesses the `"store"` field, then the `"books"` field (since it's an array), runs a filter on each item by its `"price"` (larger than 10), and finally prints the resulting list.
+The query describes a jq program. It accesses the `"store"` field and then the `"books"` field. Because `"books"` is an array, it filters each item by its `"price"`, keeping prices larger than 10, and prints the resulting list.
 
 ```json
 [
@@ -55,33 +54,33 @@ The query describes a jq program. By running it, it accesses the `"store"` field
 ]
 ```
 
-The semantics of jq consist of a set of piped operations, where each output is connected to an input where the first input is the JSON itself. Some pseudo-code to illustrate:
+A jq program consists of piped operations. Each operation's output becomes the next operation's input, with the JSON itself as the first input. Some pseudo-code to illustrate:
 
 ```
 { /* json */ } | filter | transform | count | .field
 ```
 
-In order to transform the `query` to a set of operations that run against a JSON, we will divide the problem into 3 steps: **parse**, **compile** and **run**.
+To transform the `query` into operations that run against JSON, we'll divide the problem into 3 steps: **parse**, **compile** and **run**.
 
 ### Parsing
 
-Parsing is responsible for transforming a string into an [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) (Abstract Syntax Tree), a data structure that contains the same information as the input, but in an easier shape to work with. In case the input is malformed (not following the rules), the parser can also return errors.
+Parsing transforms a string into an [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) (Abstract Syntax Tree), a data structure with the same information as the input in a shape that's easier to work with. The parser can also return errors if the input is malformed and doesn't follow the rules.
 
-One of the beauties of `jq` is that all the expressions are piped by default, so `.store | .books` is equivalent to `.store.books`. I designed the _AST_ to represent the pipe structure in its nature. If you want to know more about jq's language, check their [wiki](https://en.wikipedia.org/wiki/Abstract_syntax_tree).
+One of the beauties of `jq` is that all expressions are piped by default, so `.store | .books` is equivalent to `.store.books`. I designed the _AST_ so its structure represents that pipe. If you want to know more about jq's language, check its [wiki](https://en.wikipedia.org/wiki/Abstract_syntax_tree).
 
-Let's see an example. When the parser receives `.store.books` it will return:
+For example, when the parser receives `.store.books`, it returns:
 
 ```reason
 Pipe(Key("store"), Key("books"));
 ```
 
-All the operations are transformed into these constructors from above (`Pipe`, `Key`, etc.). Those constructors are called Variants.
+The parser transforms all operations into constructors such as `Pipe` and `Key`. These constructors are called Variants.
 
-Variants model values that may assume one of many known variations. This feature is similar to `enums` in other languages, but each variant may optionally contain data that is carried inside. Variants belong to a large group of types called [_ADTs_](https://en.wikipedia.org/wiki/Algebraic_data_type).
+Variants model values that may assume one of many known variations. This feature resembles `enums` in other languages, but each variant may optionally carry data. Variants belong to a large group of types called [_ADTs_](https://en.wikipedia.org/wiki/Algebraic_data_type).
 
 The entire `query-json` AST is one big recursive variant.
 
-Following with a more complex example, let's parse `.store.books | filter(.price > 10)`:
+A more complex example parses `.store.books | filter(.price > 10)`:
 
 ```reason
 Pipe(
@@ -90,11 +89,11 @@ Pipe(
 );
 ```
 
-Here you can see how `Pipe` is used both as the pipe `|` and as `.store.books`. You can see more examples in the [parsing tests](https://github.com/davesnx/query-json/blob/f1ae467e53447a045178673440332b6e59958b1c/test/Test_parse.ml).
+Here, `Pipe` represents both the pipe `|` and `.store.books`. The [parsing tests](https://github.com/davesnx/query-json/blob/f1ae467e53447a045178673440332b6e59958b1c/test/Test_parse.ml) contain more examples.
 
 ### Compiling
 
-The compilation step receives the _AST_ expression and transforms it to code. The compiler is a big recursive [pattern match](https://reasonml.github.io/docs/en/pattern-matching), which is another great feature of Reason/OCaml and looks something like this:
+The compilation step receives the _AST_ expression and transforms it into code. The compiler is one big recursive [pattern match](https://reasonml.github.io/docs/en/pattern-matching), another great feature of Reason/OCaml. It looks something like this:
 
 ```reason
 let rec compile = (expression, json) => {
@@ -110,13 +109,13 @@ let rec compile = (expression, json) => {
 }
 ```
 
-On the left side are defined all the possible `Variants` and on the right side each operation. Those operations transform the JSON. Here is where `map`, `filter`, `reduce`, `index`, etc. are implemented. In the real implementation, many branches call `compile` recursively.
+The left side defines every possible `Variant`, while the right side defines each operation. These operations transform the JSON. This is where `map`, `filter`, `reduce`, `index`, etc. are implemented. In the real implementation, many branches call `compile` recursively.
 
 ### Running
 
-The easier part: the compile step gives us back a curried function that expects a json as the only argument. We just apply the function to this JSON and print the result.
+This is the easier part. The compile step returns a curried function that expects a json as its only argument. We apply the function to this JSON and print the result.
 
-This example only describes the happy path. In reality, the parsing and compilation steps return a `result` type which allows handling errors.
+This example describes only the happy path. In reality, the parsing and compilation steps return a `result` type that allows error handling.
 
 ```ocaml
 let compile: Ast.expression -> Json.t -> (Json.t list, string) result
@@ -124,25 +123,25 @@ let compile: Ast.expression -> Json.t -> (Json.t list, string) result
 
 # Distribution
 
-Now we've covered how it works internally and a brief overview of the architecture. Let's dive into how developers can use it on their machines.
+We've covered how it works internally and the basic architecture. Developers can use it on their machines in the following ways.
 
 ## How to compile it
 
-query-json is built with dune, which supports ReasonML out of the box. dune (by default) can run the OCaml compiler with different backends. It can compile to bytecode (and run with the bytecode interpreter) or it can compile to binary to make a native executable.
+query-json is built with dune, which supports ReasonML out of the box. By default, dune can run the OCaml compiler with different backends. It can compile to bytecode, which runs with the bytecode interpreter, or to binary for a native executable.
 
-All of the build process and tests run on our CI in GitHub Actions: running Mac, Windows, and Linux images. I distribute the pre-built binaries for all architectures in the GitHub Releases and the npm registry.
+All build steps and tests run in our CI on GitHub Actions using Mac, Windows, and Linux images. I distribute pre-built binaries for all architectures through GitHub Releases and the npm registry.
 
-This allows users to download it directly via npm, or from the GitHub release page.
+Users can download it directly through npm or from the GitHub release page.
 
 ## How to compile to the web
 
-Apart from compiling to the executable, query-json is compiled to JavaScript as well.
+Besides compiling to an executable, query-json also compiles to JavaScript.
 
-Compilation to JavaScript is the sweet section of this blog post and the part I'm most proud of. It wasn't a big effort, since the tools I used are already mature, but being capable of releasing 2 distributables from a single codebase feels like magic, considering all query-json's dependencies ([menhir](https://opam.ocaml.org/packages/menhir/), [sedlex](https://github.com/ocaml-community/sedlex), and [yojson](https://github.com/ocaml-community/yojson)).
+Compiling to JavaScript is the part of this blog post I'm most proud of. It didn't take much effort because the tools I used are already mature. Still, releasing 2 distributables from one codebase feels like magic, especially with all of query-json's dependencies: [menhir](https://opam.ocaml.org/packages/menhir/), [sedlex](https://github.com/ocaml-community/sedlex), and [yojson](https://github.com/ocaml-community/yojson).
 
-To accomplish this, I used [js_of_ocaml](https://github.com/ocsigen/js_of_ocaml) (jsoo for short). jsoo is a compiler that uses an intermediate representation of the OCaml compiler (the bytecode I mentioned before) and transforms it to JavaScript.
+I used [js_of_ocaml](https://github.com/ocsigen/js_of_ocaml), or jsoo for short. jsoo is a compiler that takes an intermediate representation from the OCaml compiler, the bytecode I mentioned earlier, and transforms it into JavaScript.
 
-Since [dune](https://dune.build) supports jsoo out of the box, I just needed to modify its stanza by adding `(modes js)`:
+Because [dune](https://dune.build) supports jsoo out of the box, I only needed to add `(modes js)` to its stanza:
 
 ```dune
 (executable
@@ -151,13 +150,13 @@ Since [dune](https://dune.build) supports jsoo out of the box, I just needed to 
  (libraries console.lib source yojson js_of_ocaml))
 ```
 
-After running `dune build`, I had a big file `Js.bc.js` with all the code bundled. Kind of amazing, tbh.
+After running `dune build`, I had a big file named `Js.bc.js` with all the code bundled. That was kind of amazing, tbh.
 
 ## Building query-json's playground
 
-After compiling to JavaScript, I built a web playground where people could try query-json without installing anything. This made the tool immediately accessible—no downloads, no setup, just open a browser and start typing.
+After compiling to JavaScript, I built a web playground where people could try query-json without installing anything. This made the tool immediately accessible. They could open a browser and start typing, with no downloads or setup.
 
-Beyond user accessibility, the playground brought some nice benefits: I could deploy preview versions on every pull request, users could share bug reports via a single URL, and everything ran faster since it executed locally in the browser.
+The playground also brought some nice benefits. I could deploy preview versions for every pull request, users could share bug reports through a single URL, and everything ran faster because it executed locally in the browser.
 
 ![](/images/query-json-playground.png)
 
@@ -165,37 +164,37 @@ The playground is built with jsoo and a few cool dependencies: [jsoo-react](http
 
 https://query-json.netlify.app
 
-The query-json execution runs on each keystroke, which means the playground runs offline. Comparing this with the official [jq playground](https://jqplay.org/), which needs to communicate with a backend, run jq there, and return the response, it's night and day.
+The playground runs query-json on each keystroke, so it also works offline. The official [jq playground](https://jqplay.org/) needs to communicate with a backend, run jq there, and return the response. The difference is night and day.
 
-Having a playground as a serverless frontend app is a massive improvement over a backend-dependent one. Faster, safer, more scalable and accessible to everybody.
+A playground built as a serverless frontend app is a massive improvement over one that depends on a backend. It's faster, safer, more scalable, and accessible to everybody.
 
 ### Benefits
 
-Using jsoo seems a powerful way to run your OCaml code in a browser without much hassle. This was a key takeaway for me while making this project possible. But distribution isn't the only benefit—here's a list of other upsides in my opinion:
+I found jsoo to be a powerful way to run OCaml code in a browser without much hassle. That was a key takeaway for me, and it helped make this project possible. In my opinion, it also offers these benefits beyond distribution:
 
 - **Portability**: moving code from server to client or vice versa, sharing marshal/unmarshal code, easier contract testing.
-- **Familiarity**: writing the same patterns benefits newcomers who need to learn fewer platform-specific rules.
-- **Usage of OCaml's ecosystem**: access to many libraries and ppxs and latest OCaml features.
-- **New possibilities**: some apps might benefit from server-side rendering, others from moving functionality offline, and many app-specific designs that are unblocked by this.
+- **Familiarity**: writing the same patterns helps newcomers learn fewer platform-specific rules.
+- **Usage of OCaml's ecosystem**: access to many libraries and ppxs and the latest OCaml features.
+- **New possibilities**: some apps might benefit from server-side rendering, others from moving functionality offline, and many app-specific designs are unblocked by this.
 
-Most of the REPLs from Reason, OCaml, Flow, and ReScript (all written in OCaml) use js_of_ocaml for their playgrounds.
+Most of the REPLs for Reason, OCaml, Flow, and ReScript, all written in OCaml, use js_of_ocaml for their playgrounds.
 
 # Future
 
-query-json is still young. It supports most of jq's core features, but there's room to grow—and maybe diverge.
+query-json is still young. It supports most of jq's core features, but it has room to grow and perhaps diverge.
 
-The future of query-json is to support more constructors from the jq language and provide a better experience for running operations on JSON by having better error messages and better performance.
+I want query-json to support more constructors from the jq language and make operations on JSON easier to run through better error messages and performance.
 
-For me, jq is like a double-edged sword—very powerful but a bit confusing. The number of questions on StackOverflow.com proves that there are many problems without a solution in the language. If query-json gets a lot of traction, I would diverge from the jq syntax and try to solve those confusing parts.
+For me, jq is a double-edged sword: very powerful but also confusing. The number of questions on StackOverflow.com proves that the language has many problems without a solution. If query-json gets a lot of traction, I would diverge from jq's syntax and try to solve those confusing parts.
 
-The other mission of query-json is to push performance forward. Now we are implementing most of the missing functionality, and next is to explore performance optimizations, such as:
+Another mission of query-json is to push performance forward. We are now implementing most of the missing functionality. Next, we'll explore performance optimizations such as:
 
-- Improving the JSON parsing, such as JSON streaming, or even better, only parsing the parts that the query needs
-- Refactor it using OCaml multicore (once it's published!)
+- Improving JSON parsing through JSON streaming, or better yet, parsing only the parts that the query needs
+- Refactoring it with OCaml multicore (once it's published!)
 - Replacing menhir with a hand-written parser
 
 ## Final
 
-I hope you liked the project and the story. Let me know if you're interested in these topics. I'm always happy to chat.
+I hope you enjoyed the project and its story. Let me know if these topics interest you; I'm always happy to chat.
 
 Thanks to everyone who reviewed this blog post: [Javi](http://javierchavarri.com/), [Enric](https://twitter.com/epallerols), and [Gerard](http://gerard.sh/).

--- a/src/content/posts/hello.mdx
+++ b/src/content/posts/hello.mdx
@@ -7,12 +7,12 @@ tags:
   - "Hi"
 ---
 
-Everything needs to start at some point and here am I.
+Everything needs to start at some point, and here I am.
 
-I'm spanish, which means that I automatically suck at speaking in english. Aside, I struggle at explaining myself, but still I would love to share my thoughts on the internet about some topics that I found interesting.
+I'm Spanish, which means I automatically suck at speaking English. Besides that, I struggle to explain myself. Still, I would love to share my thoughts on the internet about topics I've found interesting.
 
-The range of topics can vary from Software, Functional Programming, ReasonML, SaaS products, design, people or anything, really.
+Topics may include Software, Functional Programming, ReasonML, SaaS products, design, people, or anything else, really.
 
-At the time of writting, I worked for almost 7 years on the Tech industry and there's a ton of stuff that I learned and planning to learn. So I will try to write down some stuff that comes to my head, share them here and hopefully it will push me to understand those topics better and, eventually teach someone along the way.
+At the time of writing, I had been working in the Tech industry for almost seven years. I've learned a ton and plan to learn a ton more. I'll try to write down whatever comes to mind and share it here. I hope this pushes me to understand those topics better and eventually lets me teach someone along the way.
 
 If you want to know more about me, visit the [about](/about) page or follow me on [twitter](https://twitter.com/davesnx).

--- a/src/content/posts/learning-ocaml.mdx
+++ b/src/content/posts/learning-ocaml.mdx
@@ -7,21 +7,21 @@ tags:
   - "OCaml"
 ---
 
-If you’re new to OCaml you may find the ecosystem confusing. There are a few reasons for this:
+If you're new to OCaml, you may find the ecosystem confusing. There are a few reasons for this:
 
-- OCaml has been born in academia and historically been focused in type-theory and functional programming
-- The community has a fame of being small
-- It was created long time ago and it carries some of the old-fashion methods from the past
-- It's a functional programming language, which it might be different paradigm than the one you're used to
-- Really well suited to create a programming language but got into more general purpose programming
+- OCaml was born in academia and has historically focused on type theory and functional programming
+- The community has a reputation for being small
+- It was created a long time ago and carries some old-fashioned methods from the past
+- It's a functional programming language, which may be a different paradigm from the one you're used to
+- It's well suited to creating programming languages but has expanded into general-purpose programming
 
 ## Why should you listen to me?
 
-I’m not a teacher, I don’t have 10+ years of experience in OCaml, I don’t have a PhD and more terribly I didn’t finish my Computer Science degree.
+I'm not a teacher. I don't have 10+ years of experience in OCaml or a PhD, and, more terribly, I didn't finish my Computer Science degree.
 
-But often it’s very useful to learn from someone who is one step above you, and not someone who's 10 steps above you.
+But it's often useful to learn from someone who is one step above you rather than someone who's 10 steps above you.
 
-I worked professionally in OCaml and ReasonML (a dialect of OCaml) for almost 3 years (and counting) and have been creating and maintaining some useful projects meanwhile. Some of them are:
+I've worked professionally in OCaml and ReasonML (a dialect of OCaml) for almost 3 years and counting. Meanwhile, I've created and maintained some useful projects:
 
 - [styled-ppx](https://github.com/davesnx/styled-ppx): Typed styled components for ReScript
 - [query-json](https://github.com/davesnx/query-json): Faster, simpler and more portable implementation of `jq` in Reason
@@ -32,7 +32,7 @@ I worked professionally in OCaml and ReasonML (a dialect of OCaml) for almost 3 
 
 ## How to look at the OCaml ecosystem
 
-The OCaml ecosystem seems overwhelming because it’s always explained in abstract terms, minimum explanations and probably the wrong order.
+The OCaml ecosystem seems overwhelming because it's always explained in abstract terms, with minimal explanation and probably in the wrong order.
 
 - [Basics of the language](#learning-the-basics-of-the-language)
 - [Standard lib replacements](#learning-about-standard-library-replacements)
@@ -42,7 +42,7 @@ The OCaml ecosystem seems overwhelming because it’s always explained in abstra
 - [deriving/ppx](#learning-about-ppx)
 - [Compilation modes](#learning-about-compilation-modes-native-byte-js)
 
-Additionally, there are a few topics that are often mentioned as "more advanced". The topics below are interesting, but they're difficult to understand, are far less popular than the above topics and **aren't required for most apps** but they can became immensely helpful when some specific problem appears.
+A few topics are often described as "more advanced." The topics below are interesting, but they're difficult to understand, far less popular than the ones above and **aren't required for most apps**. They can still become immensely helpful when a specific problem appears.
 
 - [Functors](#learning-functors)
 - [GADTs](#learning-gadts)
@@ -57,35 +57,35 @@ Additionally, there are a few topics that are often mentioned as "more advanced"
 
 [ocaml.org/docs/up-and-running](https://ocaml.org/docs/up-and-running)
 
-Similarly on the [first-hour](https://ocaml.org/docs/first-hour) from the OCaml docs, here's a quick overview of the core of the language to get you up and running.
+Like the [first-hour](https://ocaml.org/docs/first-hour) guide in the OCaml docs, this is a quick overview of the core language to get you up and running.
 
 ### Types
 
-OCaml is a statically typed functional programming language. Unless other languages, OCaml has inference which means it's not necessary to specify the type of every variable/argument/return value.
+OCaml is a statically typed functional programming language with type inference, so you don't need to specify every variable, argument, or return type.
 
 ```ocaml
 let fn x = x + 1
 (* fn: int -> int *)
 ```
 
-Note: `fn` is a function that takes an `int` and returns an `int`, any other type will make the compiler angry. The compiler will infer the type as `int` since the `+` operator is just for ints. To sum floats, the operator is `+.`.
+Note: `fn` is a function that takes an `int` and returns an `int`. Any other type will make the compiler angry. The compiler infers the type as `int` because the `+` operator works only with ints. To sum floats, use the `+.` operator.
 
 The most important built-in types are records, tuples and variants.
 
-- `records` are used to define a data structure with a fixed set of fields. They are used to hold values together and define a domain model.
+- `records` define a data structure with a fixed set of fields. They hold values together and define a domain model.
 
 ```ocaml
   type person = { first_name : string; surname : string; age : int; }
 ```
 
-- `tuples` are a type with a fixed set of values, without specify their names. They're often used to associate values without creating a more formal data structure (like a record).
+- `tuples` have a fixed set of values without names. They're often used to associate values without creating a more formal data structure such as a record.
 
 ```ocaml
   let t = (1, "one", '1') in
   (*      int * string * char *)
 ```
 
-- `variants` are used to define a sum type (also known as ADTs: Algebraic Data Types). They can be used to represent a value that can be one of a few different kinds.
+- `variants` define a sum type, also known as ADTs: Algebraic Data Types. They can represent a value that may be one of a few different kinds.
 
 ```ocaml
   type color =
@@ -98,7 +98,7 @@ The most important built-in types are records, tuples and variants.
 
 ### Pattern match
 
-Pattern matching is the greatest feature of OCaml, it allows to match a value against a pattern and execute code on each branch. Works amazingly well with variants but also great with records, tuples and lists.
+Pattern matching is OCaml's greatest feature. It lets you match a value against a pattern and execute code for each branch. It works amazingly well with variants and is also great with records, tuples and lists.
 
 ```ocaml
 match color with
@@ -108,7 +108,7 @@ match color with
 | RGB (r, g, b) -> "rgb(" ^ string_of_int r ^ "," ^ string_of_int g ^ "," ^ string_of_int b ^ ")"
 ```
 
-The compiler enforces that you pattern matching defines all possible cases. If I forgot a case, such as `| Yellow` the compiler will say:
+The compiler enforces that your pattern match defines every possible case. If I forget a case, such as `| Yellow`, the compiler will say:
 
 ```sh
 Warning number 8
@@ -117,13 +117,13 @@ You forgot to handle a possible case here, for example:
 **Yellow**
 ```
 
-Pattern match it will be one of your most (ab)used features of OCaml and can be combined with almost any feature of the language and became very advance topic. Here's a more extensive example: [Mathematical expressions](https://ocaml.org/docs/data-types#example-mathematical-expressions)
+Pattern matching will become one of your most (ab)used OCaml features. You can combine it with almost any other feature of the language, and it can become a very advanced topic. For a more extensive example, see [Mathematical expressions](https://ocaml.org/docs/data-types#example-mathematical-expressions).
 
 ### Balance of styles
 
-OCaml has the right balance between Functional language and imperative styles. Allows you to write code in both, it's often preferred to stick to functional and ocassionaly opt-out to imperative.
+OCaml has the right balance between functional and imperative styles. It lets you write both, though it's often preferable to stick to functional code and occasionally opt out into imperative code.
 
-By default, all values are immutable. `List.map` will return a new list, instead of mutating the original one.
+By default, all values are immutable. `List.map` returns a new list instead of mutating the original one.
 
 ```ocaml
 let data = [1, 2, 3] in
@@ -131,9 +131,9 @@ let data_plus_one = List.map (fun x => x + 1) data in
 (* `data_plus_one` is a new list and `data` is still available in scope *)
 ```
 
-But it's possible to mutate values using `ref` and `mutable` keyword (inside records). Extensive explanation [here](https://cs3110.github.io/textbook/chapters/mut/refs.html)
+But you can mutate values with `ref` and the `mutable` keyword inside records. There's an extensive explanation [here](https://cs3110.github.io/textbook/chapters/mut/refs.html).
 
-Similarly on the above, you can debug values by printing to the stdout with `print_endline` or [`Printf`](https://v2.ocaml.org/api/Printf.html). The `Printf` module comes with a lot of useful functions to format your output, and similarly to C with the printing notation: `%s` for strings, `%d` for integers, `%f` for floats, etc.
+Along the same lines, you can debug values by printing to stdout with `print_endline` or [`Printf`](https://v2.ocaml.org/api/Printf.html). The `Printf` module has many useful functions for formatting output. Its printing notation is similar to C: `%s` for strings, `%d` for integers, `%f` for floats, etc.
 
 ```ocaml
 print_endline "Hello world";
@@ -142,15 +142,15 @@ print_endline "Hello world";
 
 ### Modules
 
-Modules are the way to organize your code in OCaml. Each file is an implicit module that uses the name of the file. You can create modules inside with `module Whatever = { ... }`.
+Modules are how you organize code in OCaml. Each file is an implicit module that uses the file's name. You can create modules inside it with `module Whatever = { ... }`.
 
-> Note: All modules need to start by an uppercase letter.
+> Note: All modules need to start with an uppercase letter.
 
-You will find modules often have a `type t` which representes the "main" type of the module. For example, the `List` module has a `type t` which is `'a list` (a list of any type).
+You'll often find that modules have a `type t` representing the module's "main" type. For example, the `List` module has a `type t` that is `'a list`, a list of any type.
 
-Modules can import other modules using `include` makes all functions/types from the included module available in the current module.
+Modules can import other modules with `include`, which makes every function and type from the included module available in the current module.
 
-You can `open` modules as well, removing the need to prefix all values/functions/types by the module.
+You can also `open` modules, removing the need to prefix every value, function and type with the module name.
 
 {/* ### Syntax */}
 {/* Syntax matters */}
@@ -163,65 +163,64 @@ You can `open` modules as well, removing the need to prefix all values/functions
 
 [opam.ocaml.org/](https://opam.ocaml.org/)
 
-`opam` is the OCaml's package manager. Read [this post](https://khady.info/opam-npm.html) to feel familiar with the basics. It can create a "switch" (a set of packages for each project attached to a version of the compiler). Download packages and install
+`opam` is OCaml's package manager. Read [this post](https://khady.info/opam-npm.html) to become familiar with the basics. It can create a "switch," a set of packages for each project attached to a compiler version, as well as download and install packages.
 
 ## Learning dune
 
 [dune.readthedocs.io/en/stable/overview.html](https://dune.readthedocs.io/en/stable/overview.html)
 
-Dune is the most common build system for OCaml projects. It's power comes from the fact that the user can define a build system in a declarative way and `dune` takes care of most low-level details of OCaml compilations, creation of libraries/executables.
+Dune is the most common build system for OCaml projects. Its power comes from letting users define a build system declaratively while `dune` handles most of the low-level details of OCaml compilation and the creation of libraries and executables.
 
-I recommend creating a dummy project following this guide: [Building a Hello World Program From Scratch](https://dune.readthedocs.io/en/stable/quick-start.html#building-a-hello-world-program-from-scratch) and try to understand the `dune` file and how modules are organized.
+I recommend creating a dummy project by following [Building a Hello World Program From Scratch](https://dune.readthedocs.io/en/stable/quick-start.html#building-a-hello-world-program-from-scratch). Try to understand the `dune` file and how the modules are organized.
 
 ## Configure Editor
 
 [github.com/ocaml/ocaml-lsp](https://github.com/ocaml/ocaml-lsp)
 
-Merlin and ocaml-lsp-server (OCaml's Language Server Protocol) are the tools to enhance editors (like Visual Studio Code, Vim, or Emacs) by providing many useful features such as "jump to definition", "type on hover", "refactor symbol", "autocomplete", "expand switch statement", "create an interface file from an implementation", etc...
+Merlin and ocaml-lsp-server (OCaml's Language Server Protocol) enhance editors such as Visual Studio Code, Vim and Emacs. They provide useful features such as "jump to definition," "type on hover," "refactor symbol," "autocomplete," "expand switch statement" and "create an interface file from an implementation."
 
-Setup your preferred IDE by following [this](http://ocamlverse.net/content/editor_setup.html).
+Set up your preferred IDE by following [this guide](http://ocamlverse.net/content/editor_setup.html).
 
 ## Learning about standard library replacements
 
-In addition to the OCaml standard library, there are several popular third-party libraries that are widely used in the OCaml community. Some of these libraries provide alternative implementations of certain features, while others offer additional functionality that is not available.
+In addition to the OCaml standard library, several popular third-party libraries are widely used in the OCaml community. Some provide alternative implementations of certain features, while others offer functionality that isn't available in the standard library.
 
 - Base: [janestreet/base](https://github.com/janestreet/base)
 - Core: [janestreet/core](https://github.com/janestreet/core)
 - Containers: [c-cube/ocaml-containers](https://github.com/c-cube/ocaml-containers)
 - devkit: [ahrefs/devkit](https://github.com/ahrefs/devkit)
 
-Even thought most of these might be handy, I recommend to start with the Standard library and explore what's missing and try to reach for one of these when the time comes. Knowing that they exist and they are used in some online materials is good enough to move forward.
+Even though most of these might be handy, I recommend starting with the standard library, exploring what's missing and reaching for one of these when the time comes. Knowing that they exist and appear in some online materials is enough to move forward.
 
 ## Learning about ppx
 
 [ocaml.org/docs/metaprogramming](https://ocaml.org/docs/metaprogramming)
 
-What are these `[@deriving yojson]`, `[@react.component]`, `[%...]`, `[@@ ...]`, `let%lwt` annotations?
-Those annotations are called `ppx` or **p**re**p**rocessing e**x**tension and they do a lot of stuff for you. They are used to generate code, either by extending the language or by generating boilerplate code.
+What are the `[@deriving yojson]`, `[@react.component]`, `[%...]`, `[@@ ...]` and `let%lwt` annotations? They're called `ppx`, or **p**re**p**rocessing e**x**tensions, and they do a lot for you. They generate code by either extending the language or producing boilerplate.
 
-This is often called meta-programmig and it's a very powerful tool and also very easy to abuse it. In the official documentation there's an extensive explanation of [Preprocessors in OCaml](https://ocaml.org/docs/metaprogramming).
+This is often called meta-programming. It's a powerful tool that's also very easy to abuse. The official documentation has an extensive explanation of [Preprocessors in OCaml](https://ocaml.org/docs/metaprogramming).
 
 ## Learning about Compilation modes: native, byte, js
 
-One of the strengths of OCaml is that it can be compiled to run on a wide variety of platforms: native code, bytecode and JavaScript.
+One of OCaml's strengths is that it can be compiled to run on a wide variety of platforms: native code, bytecode and JavaScript.
 
-OCaml by itself comprises two compilers:
+OCaml itself comprises two compilers.
 
-One generates bytecode which is then interpreted by a C program. This compiler runs quickly, generates compact code with moderate memory requirements, and is portable to essentially any 32 or 64 bit Unix platform. Performance of generated programs is quite good for a bytecoded implementation. This compiler can be used either as a standalone, batch-oriented compiler that produces standalone programs, or as an interactive, toplevel-based system.
+One generates bytecode, which a C program then interprets. This compiler runs quickly, generates compact code with moderate memory requirements and is portable to essentially any 32- or 64-bit Unix platform. The generated programs perform quite well for a bytecode implementation. You can use this compiler either as a standalone, batch-oriented compiler that produces standalone programs or as an interactive, toplevel-based system.
 
-The other compiler generates high-performance native code for a number of processors. Compilation takes longer and generates bigger code, but the generated programs deliver excellent performance, while retaining the moderate memory requirements of the bytecode compiler.
+The other compiler generates high-performance native code for several processors. Compilation takes longer and generates larger code, but the programs deliver excellent performance while retaining the bytecode compiler's moderate memory requirements.
 
 There are also two compilers that target JavaScript: js_of_ocaml and Melange.
 
-[js_of_ocaml](https://github.com/ocsigen/js_of_ocaml) tries to work closely with the OCaml ecosystem of libraries, allowing to compile to JavaScript any OCaml library.
+[js_of_ocaml](https://github.com/ocsigen/js_of_ocaml) tries to work closely with the OCaml library ecosystem, allowing any OCaml library to compile to JavaScript.
 
-[Melange](https://github.com/melange-re/melange) integrates closer with the JavaScript/npm ecosystems.
+[Melange](https://github.com/melange-re/melange) integrates more closely with the JavaScript/npm ecosystems.
 
 ## Learning Functors
 
 [dev.realworldocaml.org/functors.html](https://dev.realworldocaml.org/functors.html)
 
-Functors are a way to parameterize modules over other modules. They are used in modules from the Standard Library such as `Map` and `Set`.
+Functors are a way to parameterize modules over other modules. Modules from the Standard Library, such as `Map` and `Set`, use them.
 
 ```ocaml
 module Map_with_strings = Map.Make(String)
@@ -274,11 +273,11 @@ module Map = struct
 end
 ```
 
-An specific [example of a Functor](https://www.thekerneltrip.com/ocaml/ocaml-functor-example/)
+A specific [example of a Functor](https://www.thekerneltrip.com/ocaml/ocaml-functor-example/)
 
 ## Learning about memory management
 
-OCaml provides a garbage collector so that you don't need to explicitly allocate and free memory as in C/C++. The OCaml garbage collector is a modern hybrid generational/incremental collector which outperforms hand-allocation in most cases.
+OCaml provides a garbage collector, so you don't need to allocate and free memory explicitly as you do in C/C++. The OCaml garbage collector is a modern hybrid generational/incremental collector that outperforms hand allocation in most cases.
 
 {/* Add a resource */}
 
@@ -286,11 +285,11 @@ OCaml provides a garbage collector so that you don't need to explicitly allocate
 
 [ocaml.org/manual/gadts-tutorial.html](https://v2.ocaml.org/manual/gadts-tutorial.html)
 
-GADTs (Generalized Algebraic Datatypes) are a different kind of variants (ADTs). They enable a few use cases for the typechcker that are not possible with normal variants to express polymorphism (in the sense of a function being able to return different types depending on the input).
+GADTs (Generalized Algebraic Datatypes) are a different kind of variant (ADT). They enable typechecker use cases that normal variants can't express, including polymorphism in the sense that a function can return different types depending on the input.
 
-It's very sophisticated and it's not something you'll need to use often, but it's good to know, for example the [Printf implementation](https://github.com/ocaml/ocaml/blob/trunk/stdlib/camlinternalFormatBasics.ml) or
+They're very sophisticated and aren't something you'll need to use often, but they're good to recognize in code such as the [Printf implementation](https://github.com/ocaml/ocaml/blob/trunk/stdlib/camlinternalFormatBasics.ml).
 
-The best resource I read to understand the basics though is [blog.mads-hartmann.com/ocaml/2015/01/05/gadt-ocaml.html](https://blog.mads-hartmann.com/ocaml/2015/01/05/gadt-ocaml.html).
+The best resource I've read for understanding the basics is [blog.mads-hartmann.com/ocaml/2015/01/05/gadt-ocaml.html](https://blog.mads-hartmann.com/ocaml/2015/01/05/gadt-ocaml.html).
 
 ---
 

--- a/src/content/posts/making-html-of-jsx-10x-faster.mdx
+++ b/src/content/posts/making-html-of-jsx-10x-faster.mdx
@@ -9,15 +9,15 @@ tags:
   - "SSR"
 ---
 
-Server-side rendering should be as fast as possible. I've been working on this problem for a while now (with [server-reason-react](https://github.com/ml-in-barcelona/server-reason-react) and [html_of_jsx](https://github.com/davesnx/html_of_jsx)) and I have plenty of optimizations to do.
+Server-side rendering should be as fast as possible. I've been working on this problem for a while now with [server-reason-react](https://github.com/ml-in-barcelona/server-reason-react) and [html_of_jsx](https://github.com/davesnx/html_of_jsx), and I have plenty of optimizations to do.
 
-Each time I dig into performance, I arrive at the same insight: the first step is to avoid doing work that can be done earlier (and do it only once).
+Each time I dig into performance, I arrive at the same insight: the first step is to avoid doing work that can be done earlier and to do it only once.
 
-This post explains how static analysis can eliminate runtime overhead, making `html_of_jsx` between 2x and 12x faster and some assumptions that I thought were clever but turned out to be crap.
+This post explains how static analysis can eliminate runtime overhead and make `html_of_jsx` between 2x and 12x faster. It also covers some assumptions I thought were clever but that turned out to be crap.
 
 ## What is html_of_jsx
 
-html_of_jsx is an OCaml/Reason library that lets you write JSX, create your components and finally render as HTML, mostly for server-rendered applications, static sites or even HTML emails.
+html_of_jsx is an OCaml/Reason library that lets you write JSX, create your components, and finally render them as HTML, mostly for server-rendered applications, static sites, or even HTML emails.
 
 ```mlx
 let page =
@@ -72,16 +72,16 @@ This works. But consider what happens for a simple static element like `<div id=
 
 1. **Allocate** a `Node` record (4 words: 1 header + 3 fields)
 2. **Allocate** the attributes list (~14 words: cons cells + tuples + polymorphic variants + strings)
-3. **Pattern match** in `render` to identify it's a Node
+3. **Pattern match** in `render` to identify it as a Node
 4. **Pattern match** on each attribute to render it
 
-In OCaml, every heap-allocated value has a 1-word header and each field is another word. A single `<div id="container" />` ends up allocating around **~18 words** (~144 bytes on 64-bit) just to produce a 24-character string:
+In OCaml, every heap-allocated value has a 1-word header, and each field is another word. A single `<div id="container" />` ends up allocating around **~18 words** (~144 bytes on 64-bit) just to produce a 24-character string:
 
 ```html
 <div id="container"></div>
 ```
 
-Looking at a real page like [ocaml.org](https://ocaml.org), it has 590 HTML nodes, almost ~85KB of allocations for static content. There's a lot of room for improvement.
+A real page like [ocaml.org](https://ocaml.org) has 590 HTML nodes and almost ~85KB of allocations for static content. There's a lot of room for improvement.
 
 ## Rethinking the model
 
@@ -97,7 +97,7 @@ let card ~title ~content =
   </div>
 ```
 
-With the tree model, we're forced to allocate records and lists for the `div` and `p` nodes, just to put `title` and `content` in the right place. We need a different perspective.
+The tree model forces us to allocate records and lists for the `div` and `p` nodes just to put `title` and `content` in the right place. We need a different perspective.
 
 Instead of seeing it as a tree, we can see it as a **template**:
 
@@ -116,7 +116,7 @@ Instead of seeing it as a tree, we can see it as a **template**:
 
 ## Inspiration
 
-Separating the static structure from the dynamic values is a technique well-explored in other high-performance systems:
+Other high-performance systems have explored the same technique of separating static structure from dynamic values:
 
 - [Million.js](https://github.com/aidenybai/million): Optimizing compiler for React
 - [blaze-html](https://hackage.haskell.org/package/blaze-html): Haskell's blazingly fast HTML combinator library
@@ -125,7 +125,7 @@ Separating the static structure from the dynamic values is a technique well-expl
 
 ## The strategy
 
-To implement this, I introduced a **static analyzer** step in the preprocessor that walks each JSX element **during the build step** and classifies it:
+I introduced a **static analyzer** step in the preprocessor. It walks each JSX element **during the build step** and classifies it:
 
 1. **Analyze attributes**: Are all attribute values literals (`id="container"`) or do some depend on runtime values (`id={className}`)?
 
@@ -147,7 +147,7 @@ JSX.unsafe "<div id=\"container\"><span>Hello</span></div>"
          and avoids some HTML escaping logic *)
 ```
 
-The string `"<div id=\"container\"><span>Hello</span></div>"` is computed during compilation: escaping attributes, building the tag structure, etc. At runtime, it's just a constant string. Zero computation, zero allocation.
+The string `"<div id=\"container\"><span>Hello</span></div>"` is computed during compilation: escaping attributes, building the tag structure, etc. At runtime, it's a constant string. Zero computation, zero allocation.
 
 For elements with dynamic content, we can't pre-compute the full string, so we generate `Buffer`-based code that assembles the HTML at runtime:
 
@@ -164,7 +164,7 @@ let greet name =
   JSX.unsafe (Buffer.contents buf)
 ```
 
-Notice that even here, the static parts (`"<div>"` and `"</div>"`) are pre-computed string literals. Only the dynamic `name` is processed at runtime.
+Even here, the static parts (`"<div>"` and `"</div>"`) are pre-computed string literals. Only the dynamic `name` is processed at runtime.
 
 ### The results
 
@@ -177,7 +177,8 @@ Baseline (JSX.node):     ~8M renders/sec
 After:                  ~27M renders/sec   → ~3x faster
 ```
 
-For **nested static elements**, the improvement is more dramatic:
+The improvement is more dramatic for **nested static elements**:
+
 ```
 JSX.render <div><header><h1>Title</h1></header><main>...</main></div>
 
@@ -185,13 +186,13 @@ Baseline (JSX.node):     ~2M renders/sec
 After:                  ~27M renders/sec   → ~12x faster
 ```
 
-The deeper the nesting, the less construction and traversal.
+Deeper nesting avoids more construction and traversal.
 
 ## Small wins that added up
 
 ### Eliminating wrapper allocations
 
-Dynamic strings like `<div>(JSX.string name)</div>` were still inefficient. `JSX.string` wraps the value in a `String` variant that eventually gets passed to `JSX.write`, which immediately unwraps it.
+Dynamic strings like `<div>(JSX.string name)</div>` were still inefficient. `JSX.string` wraps the value in a `String` variant, which eventually gets passed to `JSX.write` and immediately unwrapped.
 
 I updated the ppx to detect `JSX.string` at compile time and generate a direct call to a new `JSX.escape` function.
 
@@ -210,15 +211,16 @@ This simple change made rendering dynamic strings **34% faster** (from ~15.5M to
 Most user-generated content doesn't contain HTML special characters (`<`, `>`, `&`, `"`, `'`).
 
 I implemented a "scan-first" strategy:
+
 1. Scan the string to find the first character that needs escaping
-2. If none found, return the original string untouched **(zero allocations)**
-3. If found, start escaping from that position onward, skipping the already-scanned prefix
+2. If none is found, return the original string untouched **(zero allocations)**
+3. If one is found, start escaping from that position onward, skipping the already-scanned prefix
 
 The common case now allocates nothing. The less common case pays with a pass, but that's probably inevitable.
 
 ## Detours: ideas that didn't work out
 
-Performance optimization is humbling. Most "obvious" improvements turn out to be slower, equivalent, or only faster in edge cases. There are some approaches I tried that seemed brilliant at the time:
+Performance optimization is humbling. Most "obvious" improvements turn out to be slower, equivalent, or only faster in edge cases. I tried several approaches that seemed brilliant at the time:
 
 - **Pre-computing exact buffer sizes**: The overhead of calculating the final size exceeded the savings from avoiding reallocation.
 
@@ -226,9 +228,9 @@ Performance optimization is humbling. Most "obvious" improvements turn out to be
 
 - **Inlining `JSX.escape` at every call site**: The compiler already inlines small functions, and the code bloat hurt instruction cache performance.
 
-- **Using `Bytes` instead of `Buffer`**: Manual byte manipulation for "more control". Buffer is already optimized for this exact use case.
+- **Using `Bytes` instead of `Buffer`**: I tried manual byte manipulation for "more control," but Buffer is already optimized for this exact use case.
 
-- **Avoiding the fast-path check in `JSX.escape`**: at first, the scan-then-escape approach seemed wasteful (two passes). But in the common case (strings that don't need escaping), returning the original pointer is a win.
+- **Avoiding the fast-path check in `JSX.escape`**: At first, the scan-then-escape approach seemed wasteful (two passes). But in the common case (strings that don't need escaping), returning the original pointer is a win.
 
 ## Conclusion
 
@@ -245,11 +247,11 @@ The improvement scales with how static your content is. Mostly-static pages (lan
 
 In retrospect, the original implementation was correct, but correctness and efficiency are different goals. Performance often bends correctness (and sometimes maintainability too!).
 
-Once I knew some of the work only needs to happen once, the optimizations became obvious, so again: the fastest code is code that doesn't run at all.
+Once I knew some of the work only needs to happen once, the optimizations became obvious. So again: the fastest code is code that doesn't run at all.
 
 ---
 
-*html_of_jsx is open source at [github.com/davesnx/html_of_jsx](https://github.com/davesnx/html_of_jsx). The code described here are available starting from version 0.0.7.*
+*html_of_jsx is open source at [github.com/davesnx/html_of_jsx](https://github.com/davesnx/html_of_jsx). The code described here is available starting from version 0.0.7.*
 
 If you have ideas for more optimizations, I'd love to hear them -> [open an issue](https://github.com/davesnx/html_of_jsx/issues/new)!
 

--- a/src/content/posts/ocaml-documentation-as-markdown.mdx
+++ b/src/content/posts/ocaml-documentation-as-markdown.mdx
@@ -10,36 +10,36 @@ tags:
   - "odoc"
 ---
 
-For a while, Melange had two documentation sites. The guides lived in [VitePress](https://vitepress.dev/) while the API reference lived in `odoc`'s generated HTML. It worked, but it was far from a great experience.
+For a while, Melange had two documentation sites. The guides lived in [VitePress](https://vitepress.dev/), while the API reference lived in `odoc`'s generated HTML. It worked, but the experience was far from great.
 
-That split was the reason I wanted markdown output from [`odoc`](https://github.com/ocaml/odoc). With dune 3.22 and odoc 3.1, `dune build @doc-markdown` now turns `.mli` and `.mld` files into Markdown files.
+That split made me want markdown output from [`odoc`](https://github.com/ocaml/odoc). With dune 3.22 and odoc 3.1, `dune build @doc-markdown` now turns `.mli` and `.mld` files into Markdown files.
 
 ```zsh
 dune build @doc-markdown
 ```
 
-I implemented both the odoc's markdown backend and the dune integration because this is the direction I wanted OCaml tooling to move toward: integrated with the rest of the world and more modern. I built it for Melange first, then started using the same flow in smaller libraries too.
+I implemented both odoc's markdown backend and the dune integration because I wanted OCaml tooling to integrate with the rest of the world and become more modern. I built it for Melange first, then started using the same flow in smaller libraries too.
 
-In this post, I want to explain why, and how you can use it too.
+In this post, I want to explain why and how you can use it too.
 
 ## Why I cared
 
-In [Melange 5.0.0](https://melange.re/v5.0.0/), we use VitePress to write most of the manual documentation with pages like: _What is Melange_, _Rationale_, _Getting Started_, etc. We use `odoc` for the API reference for built-in libraries such as `Belt`, `Js`, and `Stdlib`.
+In [Melange 5.0.0](https://melange.re/v5.0.0/), we use VitePress to write most of the manual documentation, with pages such as _What is Melange_, _Rationale_, and _Getting Started_. We use `odoc` for the API reference for built-in libraries such as `Belt`, `Js`, and `Stdlib`.
 
 ![odoc's HTML website for melange.belt](/images/belt-odoc-html.png)
 
-The current approach used `odoc`'s HTML backend, which generates a standalone site linked from our documentation. That worked, but it created a big UX barrier between the two sites:
+That approach used `odoc`'s HTML backend, which generates a standalone site linked from our documentation. It worked, but created a big UX barrier between the two sites:
 
 - Users went from a unified experience to a different one: `melange.re` is a SPA, while the generated API docs are a separate MPA with different styling
-- Navigation was not shared, the sidebars were completely different (both content and design)
+- Navigation was not shared, and the sidebars were completely different in both content and design
 - Search on `melange.re` could not find anything inside the generated HTML
-- Could not reference `melange.re` pages from inside `.mld` files
-- Language toggling was awkward because we needed separate HTML artifacts for Reason and OCaml, and it didn't persist when visiting the API references
-- And then there were all the smaller things: favicon, tracking scripts, syntax highlighting, plus the rest of the features a static site generator gives you
+- `.mld` files could not reference `melange.re` pages
+- Language toggling was awkward because we needed separate HTML artifacts for Reason and OCaml, and it did not persist when visiting the API references
+- We also had to handle smaller details such as the favicon, tracking scripts, and syntax highlighting, along with the rest of the features a static site generator gives you
 
-For those reasons, I wanted one documentation site with the API reference inside. The missing piece was markdown output from `odoc`, so another tool could build the final site from those generated files.
+For those reasons, I wanted one documentation site with the API reference inside. The missing piece was markdown output from `odoc`, which would let another tool build the final site from those generated files.
 
-In our case, that tool was VitePress, but [there are](https://docusaurus.io/) [plenty](https://www.mkdocs.org/) [of](https://www.sphinx-doc.org/) [options](https://starlight.astro.build/) [for](https://jekyllrb.com/) [this](https://gohugo.io/), or even the GitHub markdown viewer.
+In our case, that tool was VitePress, but other options include [Docusaurus](https://docusaurus.io/), [MkDocs](https://www.mkdocs.org/), [Sphinx](https://www.sphinx-doc.org/), [Starlight](https://starlight.astro.build/), [Jekyll](https://jekyllrb.com/), [Hugo](https://gohugo.io/), and even the GitHub markdown viewer.
 
 Those documentation generators are powerful, and I do not expect `odoc` to match everything they do. Markdown output lets `odoc` plug into the rest of the docs stack instead of competing with it: developers already read it on GitHub, publishing systems can consume it directly, and AI tooling is generally easier to integrate with Markdown than a generated HTML site.
 
@@ -47,11 +47,11 @@ Those documentation generators are powerful, and I do not expect `odoc` to match
 
 ![Same documentation as before (melange.belt), but as part of the `melange.re` docs](/images/belt-vitepress.png)
 
-You can visit the result live [https://melange.re/unstable/api.html](https://melange.re/unstable/api.html)
+You can visit the result at [https://melange.re/unstable/api.html](https://melange.re/unstable/api.html).
 
 ## How does it work
 
-Running `dune build @doc-markdown` reads your `.mli` and `.mld` files, passes them through `odoc`, and produces markdown files under `_build/default/_doc/_markdown/<package>/`. One module becomes one file, one `.mld` page becomes one file. The output looks something like this:
+Running `dune build @doc-markdown` reads your `.mli` and `.mld` files, passes them through `odoc`, and produces markdown files under `_build/default/_doc/_markdown/<package>/`. Each module becomes one file, and each `.mld` page becomes one file. The output looks like this:
 
 ```bash
 _doc/_markdown/
@@ -61,9 +61,9 @@ _doc/_markdown/
     page.md
 ```
 
-The simplest thing you can do is treat that directory as the thing you publish: upload `_doc/_markdown` wherever you need it or point a static host at the folder after the build.
+The simplest option is to publish that directory: upload `_doc/_markdown` wherever you need it, or point a static host at the folder after the build.
 
-When you want the markdown wired into a bigger pipeline, you have more options. You can promote generated files into your source tree with `(promote (until-clean))` so a static-site generator sees them as normal files next to your hand-written docs. Running `dune clean` removes the promoted copies, so they do not go stale. This is what I do in [parseff](https://github.com/davesnx/parseff), where a Starlight site consumes the promoted markdown. A simplified promote rule for a single page:
+You have more options when wiring the markdown into a bigger pipeline. You can promote generated files into your source tree with `(promote (until-clean))` so a static-site generator sees them as normal files next to your hand-written docs. Running `dune clean` removes the promoted copies so they do not go stale. I use this approach in [parseff](https://github.com/davesnx/parseff), where a Starlight site consumes the promoted markdown. This simplified promote rule handles a single page:
 
 ```dune
 (rule
@@ -74,9 +74,9 @@ When you want the markdown wired into a bigger pipeline, you have more options. 
  (action (copy %{first-dep} %{targets})))
 ```
 
-Both [parseff](https://github.com/davesnx/parseff) and [html_of_jsx](https://github.com/davesnx/html_of_jsx) run `dune build @doc-markdown` in GitHub Actions on push to main, then build and deploy the site. Check each repo's workflow if you want the full wiring.
+Both [parseff](https://github.com/davesnx/parseff) and [html_of_jsx](https://github.com/davesnx/html_of_jsx) run `dune build @doc-markdown` in GitHub Actions on push to main, then build and deploy the site. Check each repo's workflow for the full wiring.
 
-Once I had the markdown output, I started using the same flow in smaller libraries too. One of my favorite uses is generating `README.md` from `README.mld`.
+After I had the markdown output, I started using the same flow in smaller libraries too. One of my favorite uses is generating `README.md` from `README.mld`.
 
 ## Generate README.md from README.mld
 
@@ -138,9 +138,9 @@ You can also check toplevel examples this way. `mdx` treats them like cram tests
 
 ## Try it out and report any issue
 
-Upgrade to `dune.3.22` and `odoc.3.1` and try it. Use the obvious cases, but also explore the less obvious ones: pipe the output into your docs site, generate a `README.md`, check examples with `mdx`, or try anything else that falls out of having OCaml docs as Markdown. If you hit edge cases, please report them in the GitHub tracker: https://github.com/ocaml/odoc and tag me `@davesnx`.
+Upgrade to `dune.3.22` and `odoc.3.1` and try it. Use the obvious cases and explore the less obvious ones: pipe the output into your docs site, generate a `README.md`, check examples with `mdx`, or try anything else that comes from having OCaml docs as Markdown. If you hit edge cases, please report them in the GitHub tracker at https://github.com/ocaml/odoc and tag me `@davesnx`.
 
-This feature is still relatively experimental. Real-world feedback, especially unusual use cases, is what will improve these workflows.
+This feature is still relatively experimental. Real-world feedback, especially unusual use cases, will improve these workflows.
 
 ### References
 
@@ -154,4 +154,4 @@ This feature is still relatively experimental. Real-world feedback, especially u
 
 ### Credits
 
-Thanks to [@jonludlam](https://jon.recoil.org/) [@rgrinberg](http://rgrinberg.com/) and [@Alizter](https://github.com/Alizter) for reviewing the work that made it possible
+Thanks to [@jonludlam](https://jon.recoil.org/), [@rgrinberg](http://rgrinberg.com/), and [@Alizter](https://github.com/Alizter) for reviewing the work that made it possible.

--- a/src/content/posts/server-side-rendering-react-in-ocaml.mdx
+++ b/src/content/posts/server-side-rendering-react-in-ocaml.mdx
@@ -9,111 +9,111 @@ tags:
   - "SSR"
 ---
 
-`server-reason-react` is an implementation of `react-dom/server` and some of React's internals in OCaml. Its purpose is to render HTML markup from the server for a Reason React application natively.
+`server-reason-react` implements `react-dom/server` and some of React's internals in OCaml. It renders HTML markup natively on the server for a Reason React application.
 
-This post provides an overview of some of the concepts of the library, what it means to render React in OCaml, how we use it at [ahrefs.com](http://ahrefs.com/), a benchmark against a Node equivalent, and the future of all of this.
+This post covers the library's concepts, what it means to render React in OCaml, how we use it at [ahrefs.com](http://ahrefs.com/), a benchmark against a Node equivalent, and where all of this might go.
 
-If you are not familiar with Reason or OCaml, it's fine. The purpose of this post is not to convince you to learn or try those languages but rather to share something I built that I'm passionate about.
+If you are not familiar with Reason or OCaml, that's fine. I'm not trying to convince you to learn or try those languages. I want to share something I built and care about.
 
-I will try to explain most concepts for any developer with experience in React. Don't be scared by any niche language/technology mentioned here since I will introduce them as we go.
+I will explain most concepts for developers with React experience. Don't be scared by the niche languages or technologies; I'll introduce them as we go.
 
-The first piece of context to follow this post is to introduce Reason and OCaml for those who are not familiar with them:
+First, some context about Reason and OCaml.
 
 ## Clarity about Reason and OCaml
 
-[Reason](https://reasonml.github.io/) is a language built on top of [OCaml](https://ocaml.org), they share the compiler, the type-checker, and most tooling around. It was created by Jordan Walke to allow JavaScript developers to enjoy OCaml. Back in the days (when TypeScript was not as popular) many members from the JavaScript community were interested in Reason.
+[Reason](https://reasonml.github.io/) is a language built on top of [OCaml](https://ocaml.org). They share the compiler, type checker, and most of their tooling. Jordan Walke created Reason so JavaScript developers could enjoy OCaml. Back when TypeScript was less popular, many people in the JavaScript community were interested in Reason.
 
-OCaml is a type-safe and robust language that empowers a functional style with powerful inference. It provides a unique balance of performance, maintainability, and reliability.
+OCaml is a robust, type-safe language that supports functional programming with powerful type inference. It offers a unique balance of performance, maintainability, and reliability.
 
-Despite being a niche programming language, OCaml has made an impact on modern programming languages and language tooling. The first versions of Rust were implemented in OCaml and Meta's Flow JavaScript type checker as well, also used as the basis for ReScript an offshoot programming language which offers compiled statically typed code into JavaScript. Nowadays, OCaml is a solid option for a general programming language backed by trade firms, blockchains and SaaS companies.
+Despite being a niche programming language, OCaml has influenced modern programming languages and language tooling. The first versions of Rust were implemented in OCaml, as was Meta's Flow JavaScript type checker. OCaml also became the basis for ReScript, an offshoot language that compiles statically typed code to JavaScript. Today, OCaml is a solid general-purpose language backed by trading firms, blockchain companies, and SaaS companies.
 
-I often refer to Reason/OCaml interchangeably since they are the same for me. Reason has a different syntax that should feel familiar to JavaScript developers, but the “engine” is the same as OCaml.
+I often use Reason and OCaml interchangeably because they are the same to me. Reason has a different syntax that should feel familiar to JavaScript developers, but its “engine” is OCaml.
 
 ## ahrefs.com
 
-At ahrefs, I'm a Software engineer working on tooling. I work on maintaining the design system, styled-ppx, helping with [Melange](https://github.com/melange-re/melange) and now on server-reason-react.
+At ahrefs, I'm a software engineer working on tooling. I maintain the design system and styled-ppx, help with [Melange](https://github.com/melange-re/melange), and now work on server-reason-react.
 
-ahrefs is a comprehensive SEO toolset that provides data-driven insights and competitive analysis for digital marketers and businesses. With one of the best crawlers of the internet, we recently launched a search engine called [Yep.com](https://yep.com/about) with the goal of providing a better revenue-sharing model.
+ahrefs is a comprehensive SEO toolset that provides data-driven insights and competitive analysis for digital marketers and businesses. We have one of the best crawlers on the internet. We also recently launched a search engine called [Yep.com](https://yep.com/about), which aims to provide a better revenue-sharing model.
 
-It's written mainly in OCaml and Reason (there's a bit of Rust and C++/D) with a monorepo containing more than 1M lines of code. We value type-safety, maintainability and performance.
+ahrefs is written mainly in OCaml and Reason, with some Rust and C++/D. Its monorepo contains more than 1M lines of code. We value type safety, maintainability, and performance.
 
-The frontend parts of ahrefs are the dashboard (app.ahrefs.com), the public website (ahrefs.com), a tiny website called [wordcount.com](https://wordcount.com/) and [Yep.com](http://Yep.com).
+The frontend parts of ahrefs include the dashboard (app.ahrefs.com), the public website (ahrefs.com), a tiny website called [wordcount.com](https://wordcount.com/), and [Yep.com](http://Yep.com).
 
 ## The problem
 
-One of the initial problems with our main React application (app.ahrefs.com) was the client-side rendering.
+One of the initial problems with our main React application (app.ahrefs.com) was client-side rendering.
 
-The canonical example of this problem happens on the Header. We had to load a bunch of contextual data such as user, permissions, billing, tokens and theme. Running all of those requests on the client creates a request waterfall and often our users use more than one tool at the same time, where navigating between those is not an optimal experience. Navigation would be slow, “flashing” the header (and the entire app) while mounting each page each time can be annoying and a waste of the same requests.
+The Header was the canonical example. We had to load contextual data for the user, permissions, billing, tokens, and theme. Running all those requests on the client creates a request waterfall. Our users often use more than one tool at a time, and navigating between them was not a good experience. Navigation was slow. Mounting each page flashed the Header and the entire app while repeating the same requests.
 
-To address those issues, we implemented server-side rendering for the static parts: a “shell” app and injecting the data as regular `scripts` with serialized JSON. We used [Tyxml](https://github.com/ocsigen/tyxml), a library that generates HTML from OCaml, for creating these static templates.
+We addressed these issues by adding server-side rendering for the static parts. We rendered a “shell” app and injected the data as regular `scripts` containing serialized JSON. We used [Tyxml](https://github.com/ocsigen/tyxml), a library that generates HTML from OCaml, to create these static templates.
 
-It improved the user experience by a lot, since the HTML served contains the static part of the app, so the browser can cache it locally. But, we quickly encountered a new problem: having two separate implementations of the same component. The client version, written in React and the server version, written with Tyxml.
+This improved the user experience by a lot because the served HTML contains the static part of the app, which the browser can cache locally. But we soon hit another problem: two separate implementations of the same component. The client version used React, while the server version used Tyxml.
 
-- Not easy to share implementations or even styles between the two
-- Keeping both versions in sync with different data-requirements is too much hustle: Ensuring the server version of the component functioned correctly without data and the client one mounts on top with the interaction
+- Sharing implementations or even styles between them was difficult
+- Keeping both versions in sync with different data requirements was too much hassle. The server component had to work without data, and the client component had to mount the interaction on top
 
-The resulting tech was difficult to maintain, deterring developers from making significant changes. While this solution was adequate for some time, we sought a more scalable approach for our other frontends.
+The resulting technology was difficult to maintain and deterred developers from making significant changes. The solution worked for a while, but we wanted a more scalable approach for our other frontends.
 
-> To address some of those problems, Javi (one of my coworkers) experimented to mix Tyxml and ReasonReact and published the experiment in his blog: [javierchavarri.com/react-server-side-rendering-with-ocaml](https://www.javierchavarri.com/react-server-side-rendering-with-ocaml)
+> To address some of those problems, Javi (one of my coworkers) experimented with mixing Tyxml and ReasonReact and published the experiment on his blog: [javierchavarri.com/react-server-side-rendering-with-ocaml](https://www.javierchavarri.com/react-server-side-rendering-with-ocaml)
 
-In addition to server-side rendering (rendering in each request), we needed a different strategy for our static pages, such as Server-Side Generation (what Next.js calls Incremental Static Regeneration). Running a rendering step at build-time and populate state on each request.
+Alongside server-side rendering, which renders each request, we needed a different strategy for static pages. We wanted Server-Side Generation, which Next.js calls Incremental Static Regeneration: run a rendering step at build time and populate the state on each request.
 
-Ultimately, our goal was to use the same client components from our design system in these server templates.
+Our goal was to use the same client components from our design system in these server templates.
 
 ## First approach
 
-The common solution to this problem is to go with a node-based solution, such as Next.js, gatsby or Astro. After using gastby and react-snap for a few years and a proof of concept with Next, we weren't satisfied with any approach.
+The common solution is a Node-based framework such as Next.js, Gatsby, or Astro. After using Gatsby and react-snap for a few years, plus building a proof of concept with Next, we were not satisfied with any of them.
 
 ### Pre-rendering (SSG) with Node
 
-Running the pre-rendering step during the build and serving them via our backend in OCaml.
+One option was to run the pre-rendering step during the build and serve the results through our OCaml backend.
 
-This solution couples the build process (running in CI) with the runtime (the production and staging servers). Increased the complexity on how we were serving those static files, and how those static files became polluted with data (also known as hydration).
+This couples the build process running in CI to the runtime on the production and staging servers. It made serving static files more complex and polluted those files with data, also known as hydration.
 
-- Templates could be unsafe to hydrate and error prone
-- Needed to generate templates for each language (currently 17) and upload them on CI
-- Running the pre-rendering on CI made a weird combination, pre-rendering required to couple our OCaml backend with HTML files and be aware of purging the cache
+- Templates could be unsafe to hydrate and error-prone
+- We needed to generate templates for each language, currently 17, and upload them in CI
+- Running pre-rendering in CI created a strange combination. It coupled our OCaml backend to HTML files and required us to manage cache purging
 
 ### Running Node with SSR on production
 
-The other solution is to serve the application by Node and using OCaml as API.
+The other option was to serve the application with Node and use OCaml as the API.
 
-Placing node in front is a very common architecture that works wonderful in some teams, but there are still some drawbacks when using Node in the backend for ahrefs.
+Putting Node in front is a common architecture that works wonderfully for some teams. It still has drawbacks for the ahrefs backend.
 
-Most of our API consists of fetching from different data storages and shuffle this data to serve it. Some of those problems make it non ideal for us:
+Most of our API fetches data from different storage systems, shuffles it, and serves the result. Several characteristics of Node made it less than ideal for us:
 
-- Single-threaded nature: Node.js is inherently single-threaded, which can lead to performance issues when dealing with high-concurrency or CPU-intensive tasks.
-- Node.js isn't the best player at memory consumption. SSR applications can be memory-intensive, potentially causing resource constraints in production environments.
-- Additional burden on DevOps, as they were not happy learning another language and framework to manage, with emphasis since it's the entry-point for users.
-- Type-safety concerns: Ensuring type-safety would require either using TypeScript and maintaining separate type definitions or using Reason and compiling it to JavaScript. However, the Node.js's bindings aren't my favorite part of Reason.
-- Might lead to some duplication of logic —e.g. authentication— on both our Backend and Node.
-- Switching a request from the server to the client (or the other way around) can be challenging, potentially leading to increased complexity and maintenance efforts.
+- Single-threaded nature: Node.js is inherently single-threaded, which can cause performance issues with high concurrency or CPU-intensive tasks
+- Node.js is not the best at memory consumption. SSR applications can use a lot of memory and potentially constrain resources in production
+- It would add a burden for DevOps. They were not happy about learning another language and framework to manage, especially because it would be the entry point for users
+- Type-safety concerns: We would need to use TypeScript and maintain separate type definitions, or use Reason and compile it to JavaScript. However, Node.js bindings are not my favorite part of Reason
+- It might duplicate logic such as authentication across our backend and Node
+- Moving a request from the server to the client, or the other way around, can be difficult and increase complexity and maintenance work
 
-After discussing with my coworkers and specially Javi with his explorations on Tyxml and ReasonReact, an idea appeared: it might be possible to use the *exact same code* from the client in the server, if we re-implement or stub some stuff here and there.
+After discussing this with my coworkers, especially Javi and his experiments with Tyxml and ReasonReact, we had an idea. We might be able to use the *exact same code* on the client and server if we reimplemented or stubbed some stuff here and there.
 
-We could have the same approach on how the JavaScript ecosystem do, running the exact same React components on the server but with the twist of running native code on the server while compiled JavaScript on the client.
+We could follow the JavaScript ecosystem's approach and run the same React components on the server, with one twist: native code on the server and compiled JavaScript on the client.
 
-How hard it would be?
+How hard could it be?
 
 ## Enter server-reason-react
 
 ### reason-react
 
-The Reason parser comes with the JSX transformation out of the box, so JSX expressions are compiled down to function calls. No need to use babel, esbuild or vite in Reason.
+The Reason parser includes the JSX transformation, so it compiles JSX expressions into function calls. Reason does not need Babel, esbuild, or Vite for this.
 
 ![A Reason-React component describing a simple Counter](/images/counter-reason-component.png)
 
-`reason-react` are a set of bindings to the JavaScript version of React. So, a tiny layer for the type-system to tell the Reason code the right interface of those hooks, createElement calls, and any React API, similar on what [`.d.ts` modules](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html) are in TypeScript or [FFI in Rust](https://doc.rust-lang.org/nomicon/ffi.html).
+`reason-react` is a set of bindings to the JavaScript version of React. It is a thin type-system layer that gives Reason code the correct interface for hooks, createElement calls, and the rest of the React API. It is similar to [`.d.ts` modules](https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-d-ts.html) in TypeScript or [FFI in Rust](https://doc.rust-lang.org/nomicon/ffi.html).
 
-The repository lives here [https://github.com/reasonml/reason-react](https://github.com/reasonml/reason-react)
+The repository is at [https://github.com/reasonml/reason-react](https://github.com/reasonml/reason-react).
 
 ## What's server-reason-react?
 
-`server-reason-react` is a re-implementation of ReactDOMServer (`react-dom/server`) and some parts of React itself to generate markup from a React component but written in OCaml.
+`server-reason-react` is a reimplementation of ReactDOMServer (`react-dom/server`) and parts of React, written in OCaml, that generates markup from a React component.
 
-More precisely `ReactDOM.renderToString` and `ReactDOM.renderToStaticMarkup`
+More precisely, it implements `ReactDOM.renderToString` and `ReactDOM.renderToStaticMarkup`.
 
-To make sure this ReactDOM can represent all kinds of nodes in React: components, elements, Fragments, Providers, Consumers. Here's the `node` variant type that represents all of them:
+ReactDOM must represent every kind of React node: components, elements, Fragments, Providers, and Consumers. This `node` variant type represents all of them:
 
 ```reason
 type node =
@@ -128,9 +128,9 @@ type node =
   | Suspense({ children: node, fallback: node })
 ```
 
-It's a [variant type (aka union or ADT)](https://dev.realworldocaml.org/variants.html) and it matches with what React internally uses with [Symbols](https://github.com/facebook/react/blob/fa4314841e7fdeef6e6bc5a7722fe74dc8e9fd89/packages/shared/ReactSymbols.js#L14). It's a recursive type (`rec`) since it references itself.
+It is a [variant type (aka union or ADT)](https://dev.realworldocaml.org/variants.html), and it matches what React uses internally with [Symbols](https://github.com/facebook/react/blob/fa4314841e7fdeef6e6bc5a7722fe74dc8e9fd89/packages/shared/ReactSymbols.js#L14). It is a recursive type (`rec`) because it references itself.
 
-The actual string generation is done by traversing the component tree to generate specific HTML representation of each node. In each "node" takes into account a few details such as serialize DOM attributes, process inline styles, encode HTML and a few React particularities (such as `dangerouslySetInnerHTML` or hydration hacks).
+The implementation generates the string by traversing the component tree and producing the appropriate HTML for each node. For every node, it handles details such as serializing DOM attributes, processing inline styles, encoding HTML, and supporting React-specific behavior such as `dangerouslySetInnerHTML` and hydration hacks.
 
 ```reason
 let rec render_to_string = node =>
@@ -156,25 +156,25 @@ components and HTML representation. The original implementation uses Buffer and 
   Note: `++` is a string concatenation operator */
 ```
 
-To be sure it supports full render and hydration the same way as React does, I migrated all tests from the [ReactDOM's server test suite](https://github.com/facebook/react/tree/main/packages/react-dom/src/__tests__).
+To ensure it supports full rendering and hydration in the same way as React, I migrated all the tests from [ReactDOM's server test suite](https://github.com/facebook/react/tree/main/packages/react-dom/src/__tests__).
 
-With all of this solved, on the server rest of React such as hooks, portals or any other APIs were trivial in comparision. Most hooks do nothing: useEffect don't run. useState is only setting the initial value, all setStates are ignored. useCallback creates the function once (and probably never called). useMemo runs and gets the value.
+Once that worked, implementing the rest of React on the server, including hooks, portals, and the other APIs, was trivial by comparison. Most hooks do nothing. useEffect does not run. useState sets only the initial value, and all setStates are ignored. useCallback creates the function once, and it is probably never called. useMemo runs and returns the value.
 
-As you could guess, my implementation does a single pass on the React tree, while React.js does multiple passes, but it's on them to change it: [https://github.com/facebook/react/issues/25318](https://github.com/facebook/react/issues/25318).
+My implementation makes a single pass over the React tree, while React.js makes multiple passes. But it's on them to change that: [https://github.com/facebook/react/issues/25318](https://github.com/facebook/react/issues/25318).
 
-With all of this done, we can return those strings as HTTP responses, and we have server-side rendering working!
+We can return those strings as HTTP responses. That gives us server-side rendering.
 
 ## Benchmark
 
-The most asked question I got while I was implementing all of this, was about performance.
+The question I heard most while implementing this was about performance.
 
-The theory said that a compiled language (OCaml) should over-perform an interpreted one (JavaScript in node), even when v8 (the engine that node runs on top) is working tirelessly to optimise it. There have been many benchmarks to prove it, but does it holds true here?
+The theory was that a compiled language such as OCaml should outperform an interpreted one such as JavaScript in Node, even while v8, the engine under Node, works tirelessly to optimize it. Many benchmarks have set out to prove that theory, but does it hold here?
 
-I was curious too, but, as explained above it was not the only impetus for `server-reason-react`. In fact the implementation isn't very optimised, and not even profiled. It does try to minimise allocations and CPU cycles but there hasn't been any performance work so far.
+I was curious too, although performance was not the only reason for `server-reason-react`. The implementation has not been optimized or even profiled. It tries to minimize allocations and CPU cycles, but I have done no performance work so far.
 
-I made a small micro-benchmark before pushing to production to ensure there wasn't any regression and prove how much gain are we talking about (against a Node and bun solutions):
+Before pushing to production, I made a small microbenchmark to check for regressions and measure the gain against Node and Bun:
 
-We compared the performance of three stacks in terms of latency, requests per second (req/s), and transfer rate.
+We compared the three stacks by latency, requests per second (req/s), and transfer rate.
 
 |  | Req/s | Avg Latency | Transfer/s |
 | --- | --- | --- | --- |
@@ -182,64 +182,64 @@ We compared the performance of three stacks in terms of latency, requests per se
 | Bun | 10.3k | 24.32ms | 17.5MB |
 | server-reason-react (with OCaml) | 64.8k | 6.21ms | 155MB |
 
-It shows an approximate improvement of x10 over Node and x6 over Bun.
+The results show an approximate 10x improvement over Node and 6x over Bun.
 
-All tests are run on local under my **MacBook Pro (13-inch, M1, 2020)**, and the benchmark data comes from a demo repository: [https://github.com/ml-in-barcelona/fullstack-reason-react-demo/tree/main/benchmark](https://github.com/ml-in-barcelona/fullstack-reason-react-demo/tree/main/benchmark).
+I ran all tests locally on my **MacBook Pro (13-inch, M1, 2020)**. The benchmark data comes from this demo repository: [https://github.com/ml-in-barcelona/fullstack-reason-react-demo/tree/main/benchmark](https://github.com/ml-in-barcelona/fullstack-reason-react-demo/tree/main/benchmark).
 
-Even thought the benchmark is not very scientific and it can lie in terms of micro-benchmarking it shows the potential of this approach and validates the theory.
+The benchmark is not very scientific, and microbenchmarks can mislead. Still, it shows the potential of this approach and validates the theory.
 
 ## Status
 
-It's deployed to all users at [app.ahrefs.com](http://app.ahrefs.com) since February and planning to use it for all frontends. Although, it's not ready for consumption. The lack of documentation, the shape of the libraries and some missing APIs makes it hard to use and I don't recommend relying on it.
+It has been deployed to every user at [app.ahrefs.com](http://app.ahrefs.com) since February, and we plan to use it for all our frontends. It is not ready for general use, though. The lack of documentation, the shape of the libraries, and some missing APIs make it difficult to use. I do not recommend relying on it yet.
 
-It's open-source and the repository lives in [GitHub](https://github.com/ml-in-barcelona/server-reason-react), check it out!
+It is open source, and the repository is on [GitHub](https://github.com/ml-in-barcelona/server-reason-react). Check it out!
 
-Even with all of this, if you are still interested feel free to contact me in [Discord](https://discord.com/users/122441959414431745) or [Twitter](https://www.twitter.com/davesnx), and open issues on GitHub.
+If you are still interested, feel free to contact me on [Discord](https://discord.com/users/122441959414431745) or [Twitter](https://www.twitter.com/davesnx), or open an issue on GitHub.
 
 ## What it enables
 
-I got a little deep into some of the details about how it works for the curious minds, but the implementation doesn't matter much. What matters are the consequences:
+I went deep into the implementation details for curious readers, but the consequences matter more:
 
 ### Same code for frontend and backend
 
-The same code gets compiled to Native and JavaScript (thanks entirely to [Melange](https://github.com/melange-re/melange)). As far as I know, it can't be done in other native languages such as Rust or Go, there are many of similar solutions but they don't cross-compile the same code.
+The same code compiles to native code and JavaScript, entirely thanks to [Melange](https://github.com/melange-re/melange). As far as I know, other native languages such as Rust or Go cannot do this. Many similar solutions exist, but they do not cross-compile the same code.
 
 ![](/images/server-reason-react-graph.png)
 
-It enables full-stack applications written in Reason. It's not a matter of "one language to rule them all", but rather simplicity.
+This enables full-stack applications written in Reason. It is not about “one language to rule them all.” It is about simplicity.
 
-Simplicity on shared data types, one learning experience, one toolchain, one set of rules, etc. Even thought sharing code has some detractors (and with good reasons) once you face the troubles of maintaining big pieces of code between stacks, you appreciate a single language after-all.
+That simplicity means shared data types, one learning experience, one toolchain, one set of rules, and more. Sharing code has detractors, with good reasons. Once you have struggled to maintain large pieces of code across stacks, though, you appreciate having a single language.
 
 ### Performance is much better
 
-Performance is critical for any SSR solution, not only the rendering engine itself but the platform you are running as well. Not only the number of requests per second it supports or the memory footprint. Among many performance issues, one that stands out is the slow start. The slow start of a Node application is a barrier for current solutions. Often this problems is addressed by changing the architecture of your application by utilizing Edge computing, or a blocker to run SSR in development.
+Performance is critical for any SSR solution, both in the rendering engine and the underlying platform. Requests per second and memory footprint both matter, but slow startup stands out among the performance problems. A Node application's slow startup is a barrier for current solutions. Teams often address it by changing their application architecture to use Edge computing, and it can also block SSR in development.
 
-Here is an example of a performance benefit from OCaml. Some OCaml-based frameworks are fast enough that it can boot for each request and tear down when the session finishes. On the other hand, this is much more challenging to do with Node.
+Some OCaml-based frameworks are fast enough to boot for each request and shut down when the session ends. Doing the same with Node is much harder. This is one example of OCaml's performance advantage.
 
-Maybe with a more performant approach we can solve some of [the problems from SSR](https://github.com/theninthsky/client-side-rendering#ssr-disadvantages)
+Maybe a faster approach can solve some of [the problems from SSR](https://github.com/theninthsky/client-side-rendering#ssr-disadvantages).
 
 ### Allows further exploration of effects of React and OCaml
 
-React has been influenced by OCaml and some functional programming concepts from the start. Such as immutability, purity and eventually algebraic effects.
+OCaml and functional programming concepts have influenced React from the start, including immutability, purity, and eventually algebraic effects.
 
-Creates the base implementation for Server components, which are a deal breaker for server-reason-react. Allowing to only run components on the server and stream the output representation of it, without the client-side penalty of executing the JavaScript code, can change radically how we write our backends.
+This work creates the base implementation for Server components, which are a deal breaker for server-reason-react. Running components only on the server and streaming their output representation avoids the client-side cost of executing the JavaScript code. That can radically change how we write our backends.
 
-Recently OCaml 5.0 was released with the highly anticipated features Multicore and Effects. These new features enable the possibility of exploring some of React's concepts to be written in OCaml.
+OCaml 5.0 was recently released with the highly anticipated Multicore and Effects features. They make it possible to explore writing some of React's concepts in OCaml.
 
 ## Why you should not use it
 
-Here are main reasons why I would not adopt server-reason-react today:
+I would not adopt server-reason-react today for these reasons:
 
-- It's an entire new ecosystem: new language, new package manager, new trade-offs
-- The learning curve might be big. The tradeoffs made by OCaml do not match with some by JavaScript (or node). Probably not as big as learning how to deal with a borrow checker 😛
-- Not everyone needs this. At ahrefs it made a lot of sense, but this it may not for you.
+- It is an entirely new ecosystem with a new language, package manager, and trade-offs
+- The learning curve might be steep. OCaml makes different trade-offs from JavaScript or Node. It is probably not as big as learning to deal with a borrow checker 😛
+- Not everyone needs this. It made a lot of sense at ahrefs, but it might not for you
 - It is still very experimental
-- Requires to lift the ecosystem to work on the server, so all client-side libraries need to be ported to OCaml when needed or stub
-- Smaller community, but growing
+- It requires lifting the ecosystem to work on the server, so every client-side library must be ported to OCaml or stubbed when needed
+- The community is smaller, but growing
 
 ## Final thoughts
 
-I intentionally didn't mention **how** this is compiled, because I want to keep it short and explain Melange in future blog posts. For reference: [ahrefs is now built with Melange](https://tech.ahrefs.com/ahrefs-is-now-built-with-melange-b14f5ec56df4?gi=582fa8d9438f)
+I intentionally did not explain **how** this is compiled because I want to keep this short and explain Melange in future blog posts. For reference: [ahrefs is now built with Melange](https://tech.ahrefs.com/ahrefs-is-now-built-with-melange-b14f5ec56df4?gi=582fa8d9438f)
 
-This has been very fun and I hope I can keep pushing this stack further.
+This has been a lot of fun, and I hope I can keep pushing this stack further.
 If you are as excited as we are, come talk to us!

--- a/src/content/posts/snapshot-tests-for-your-own-ppx.mdx
+++ b/src/content/posts/snapshot-tests-for-your-own-ppx.mdx
@@ -12,35 +12,33 @@ tags:
   - "ppxlib"
 ---
 
-When building preprocessor extensions (ppx) in OCaml, testing is crucial. You want to ensure your ppx works correctly and continues to work as you make changes. After experimenting with different approaches, I've found that cram tests fit well for the task.
+Testing is crucial when building preprocessor extensions (ppx) in OCaml. You want to ensure your ppx works correctly and continues to work as you make changes. After experimenting with different approaches, I've found that cram tests fit the task well.
 
 ## Why cram tests?
 
-As explained in my [previous post](/blog/cram-tests-a-hidden-gem-of-dune), cram tests are essentially command-line snapshot test sessions.
+As I explained in my [previous post](/blog/cram-tests-a-hidden-gem-of-dune), cram tests are essentially command-line snapshot test sessions.
 
-They're simple text files that contain commands and their expected output, which makes them particularly valuable for ppx development:
+They're simple text files containing commands and their expected output, which makes them particularly valuable for ppx development:
 
 1. They act as **living documentation**, showing exactly how your ppx behaves in different scenarios
-2. They make it **easy to report bugs** - users can simply share a cram test that demonstrates the issue
+2. They make it **easy to report bugs** because users can simply share a cram test that demonstrates the issue
 3. They provide a **sandboxed environment that mimics real-world usage**
 
-I would assume that just the fact that you are reading this, you are already convinced that’s a good idea and if there was something left, with the previous 3 items packed with good arguments, I count it as done.
+I assume that if you're reading this, you're already convinced it's a good idea. If you had any doubts left, I count those three arguments as enough to close the case.
 
 ## How to
 
-Let’s start with the how to... you need an opam switch, a dune project, a ppx and almost ready to go. If you miss some of those, check this repository https://github.com/ml-in-barcelona/ppxlib-simple-example to have a minimum setup.
+Let's get into the how-to. Once you have an opam switch, a dune project, and a ppx, you're almost ready to go. If you're missing any of those, check https://github.com/ml-in-barcelona/ppxlib-simple-example for a minimal setup.
 
-Unrelated to testing, but if you want to learn more about ppxes check [ppx-by-example](https://github.com/pedrobslisboa/ppx-by-example).
+This is unrelated to testing, but if you want to learn more about ppxes, check [ppx-by-example](https://github.com/pedrobslisboa/ppx-by-example).
 
 ## Setup the tests
 
-The goal here is to make our ppx transformations accessible to our tests via an executable, but wait!
-
-It might be benefitial to understand a bit of the dune's model. before writing any tests. Before writing any tests, it's helpful to understand how Dune organizes build artifacts and executables.
+The goal is to make our ppx transformations accessible to our tests through an executable. Before writing any tests, it helps to understand how Dune organizes build artifacts and executables.
 
 ### How dune works
 
-dune scans your project looking for dune files. When it finds one, it generates build artifacts in the _build directory. The contents of these dune files determine exactly what gets built.
+Dune scans your project for dune files. When it finds one, it generates build artifacts in the _build directory. The contents of these dune files determine exactly what gets built.
 
 For example, when you specify a ppx rewriter:
 
@@ -51,7 +49,7 @@ For example, when you specify a ppx rewriter:
   (preprocess (pps my-ppx)))
 ```
 
-dune looks for a library marked as a ppx rewriter (the `public_name` is what matters)
+Dune looks for a library marked as a ppx rewriter. The `public_name` is what matters.
 
 ```dune
 (library
@@ -60,11 +58,11 @@ dune looks for a library marked as a ppx rewriter (the `public_name` is what mat
   (kind ppx_rewriter))
 ```
 
-From this, it creates a "driver" - a single executable that can contain multiple ppx transformations and is optimised to run across your codebase.
+From this, Dune creates a "driver": a single executable that can contain multiple ppx transformations and is optimised to run across your codebase.
 
 ## Building Executables
 
-When dune finds an executable and run the build it will generate an executable in the `_build/default/src/` folder, called `my_program.exe`.
+When Dune finds an executable and runs the build, it generates an executable called `my_program.exe` in the `_build/default/src/` folder.
 
 ```dune
 (executable
@@ -79,9 +77,9 @@ If you add a public name:
   (public_name my-program))
 ```
 
-The executable becomes available at `_build/install/default/bin/my-program`. This makes it accessible both within your project and to users who install your package. Similar to adding a [install stanza to your dune file](https://dune.readthedocs.io/en/stable/reference/dune/install.html).
+The executable becomes available at `_build/install/default/bin/my-program`. This makes it accessible within your project and to users who install your package, similar to adding an [install stanza to your dune file](https://dune.readthedocs.io/en/stable/reference/dune/install.html).
 
-Here's are the steps to achieve this:
+These are the steps:
 
 ### 1. Create a executable in your dune file
 
@@ -105,9 +103,9 @@ I would keep the executable inside the tests folder, but you can put it anywhere
 let () = Ppxlib.Driver.standalone ()
 ```
 
-This exposes your ppx transfomrations with ppxlib's [`Driver.standalone`](https://ocaml-ppx.github.io/ppxlib/ppxlib/Ppxlib/Driver/index.html) which defines a CLI to run your ppx transformations directly, and simulates what dune exposes to your users when your ppx is part of a build-step in a project.
+This exposes your ppx transformations through ppxlib's [`Driver.standalone`](https://ocaml-ppx.github.io/ppxlib/ppxlib/Ppxlib/Driver/index.html), which defines a CLI for running your ppx transformations directly. It also simulates what Dune exposes to your users when your ppx is part of a build step in a project.
 
-There are a few other ways to make the executable available, explained in my previous post about cram tests: [make your executable available under cram tests](https://sancho.dev/blog/cram-tests-a-hidden-gem-of-dune#make-your-executable-available-under-cram-tests), but this is the simplest one.
+My previous post about cram tests explains a few other ways to make the executable available: [make your executable available under cram tests](https://sancho.dev/blog/cram-tests-a-hidden-gem-of-dune#make-your-executable-available-under-cram-tests). This is the simplest one.
 
 ### 3. Let cram depend on your executable
 
@@ -128,13 +126,13 @@ Let's create a simple test file called `first_step.t` and run it with `dune runt
   standalone.exe
 ```
 
-Usually I keep a Makefile with the following commands: `test`, `test-watch` and `test-promote` to feel like I’m typing the minimum of the minimum to get the job done. As you can see in this [Makefile](https://github.com/davesnx/html_of_jsx/blob/d038d4bf4301512fdbd30f98877d6d6720b9568d/Makefile#L34-L44).
+I usually keep a Makefile with the commands `test`, `test-watch`, and `test-promote` so I can type the bare minimum to get the job done, as in this [Makefile](https://github.com/davesnx/html_of_jsx/blob/d038d4bf4301512fdbd30f98877d6d6720b9568d/Makefile#L34-L44).
 
 ## Example from ppxlib-simple-example repo
 
-Say we have a ppx that does the minimum possible transformation (a foobar-kind example), which is to change the extension `[%yay]` into a string `"Hello future compiler engineer!"`.
+Say we have a ppx that performs the smallest possible transformation, a foobar-kind example: it changes the extension `[%yay]` into the string `"Hello future compiler engineer!"`.
 
-Here's what a cram test for it might look like:
+A cram test for it might look like this:
 
 ```cram
 Creates an file with some OCaml code using bash heredoc
@@ -150,9 +148,9 @@ Run the executable from input.ml and print the output to stdout
 
 ## Enhance cram tests with `ocamlc`
 
-A real-example of a ppx, is browser_ppx which handles browser-specific code by stripping it out when not targeting JavaScript. Very useful when sharing code between native and JavaScript. The documentation lives [here](https://ml-in-barcelona.github.io/server-reason-react/local/server-reason-react/browser_only.html) and comes from [server-reason-react](https://github.com/ml-in-barcelona/server-reason-react).
+A real example is browser_ppx, a ppx that handles browser-specific code by stripping it out when the target is not JavaScript. This is very useful when sharing code between native and JavaScript. Its documentation lives [here](https://ml-in-barcelona.github.io/server-reason-react/local/server-reason-react/browser_only.html) and comes from [server-reason-react](https://github.com/ml-in-barcelona/server-reason-react).
 
-Here's what a cram test for this might look like
+A cram test for it might look like this:
 
 ```cram
   $ cat > input.ml << EOF
@@ -190,13 +188,13 @@ Run the compiler
   [2]
 ```
 
-The test verifies that the ppx transforms our browser-specific code into an `[%ocaml.error ...]` and raises the error defined in the ppx, runs the compiler and checks the output. Note that the `ocamlc` command returns the error code 2 defined in the last line of the output `[2]`.
+The test verifies that the ppx transforms our browser-specific code into an `[%ocaml.error ...]` and raises the error defined in the ppx. It then runs the compiler and checks the output. The `ocamlc` command returns error code 2, shown in the last line of the output as `[2]`.
 
 ## Enhance cram tests with `ocamlmerlin`
 
-In a real world scenario like [reason-react-ppx](https://github.com/reason/reason-react), we want to ensure that the ppx transformations respect the AST location of the original code. We want the generated code to have the same location as the original code, so the editor can highlight the correct line, compiler errors report the correct line and column, etc.
+In a real-world scenario like [reason-react-ppx](https://github.com/reason/reason-react), we want to ensure that the ppx transformations preserve the AST location of the original code. The generated code should have the same location as the original code so the editor can highlight the correct line, compiler errors can report the correct line and column, and so on.
 
-For those tests we use `ocamlmerlin` to inspect the AST and ensure the location is correct. Here's a piece of the test:
+For these tests, we use `ocamlmerlin` to inspect the AST and ensure the location is correct. Here is part of the test:
 
 ```cram
 
@@ -243,20 +241,20 @@ Use ocamlmerlin to query the type of the expression at the cursor
   }
 ```
 
-Here the key learning is to use all the tools you have at your disposal (such as `ocamlmerlin`) to ensure your ppx works as expected. This is incredibly useful since many tools in OCaml are just CLIs, such as:
+The key lesson is to use all the tools at your disposal, such as `ocamlmerlin`, to ensure your ppx works as expected. This is especially useful because many OCaml tools are CLIs:
 
-- `ocamlmerlin` a LSP library used by many editors to provide code analysis
-- `ocamlc` the bytecode OCaml compiler
-- `ocamlopt` the native OCaml compiler
-- `ocamldep` the dependency resolver
-- `ocamldoc` the OCaml documentation generator
-- `ocamlformat` formatter for OCaml code
+- `ocamlmerlin` is an LSP library used by many editors to provide code analysis
+- `ocamlc` is the bytecode OCaml compiler
+- `ocamlopt` is the native OCaml compiler
+- `ocamldep` is the dependency resolver
+- `ocamldoc` is the OCaml documentation generator
+- `ocamlformat` is the OCaml code formatter
 
-More tools are available, check the [OCaml documentation](https://ocaml.org/manual/5.2/index.html#sec339) for more.
+For more tools, check the [OCaml documentation](https://ocaml.org/manual/5.2/index.html#sec339).
 
 ## Conclusion
 
-If you're building a ppx, I highly recommend giving cram tests a try. They might just make your development process a bit more enjoyable, but not only that, it will make a easy way to add all cases that you want to keep supporting on the future, or ensure edge-cases of the language remain working.
+If you're building a ppx, I highly recommend trying cram tests. They might make your development process a bit more enjoyable. They also give you an easy way to add all the cases you want to keep supporting in the future or ensure that language edge cases continue to work.
 
 Check the [ppxlib-simple-example](https://github.com/ml-in-barcelona/ppxlib-simple-example) repository for a complete example.
 

--- a/src/content/posts/tailwind-and-design-systems.mdx
+++ b/src/content/posts/tailwind-and-design-systems.mdx
@@ -10,42 +10,39 @@ tags:
   - "Components"
 ---
 
-Don’t use Tailwind for your design system, UI framework or component system, call it whatever you prefer. Tailwind isn't component-driven, although it claims to be, and you might struggle to develop a design system with it. I will explain why in this post.
+Don't use Tailwind for your design system, UI framework, or component system, whatever you prefer to call it. Tailwind isn't component-driven, although it claims to be, and you might struggle to develop a design system with it.
 
-I have recently read a lot of opinions about Tailwind ([mxstbr's thoughts](https://mxstbr.com/thoughts/tailwind), [jaredcwhite's opinion](https://dev.to/jaredcwhite/why-tailwind-isn-t-for-me-5c90), [Tailwind versus BEM](https://thoughtbot.com/blog/tailwind-versus-bem)) and while I agree with many of the points made, I have a different perspective.
+I have recently read a lot of opinions about Tailwind, including [mxstbr's thoughts](https://mxstbr.com/thoughts/tailwind), [jaredcwhite's opinion](https://dev.to/jaredcwhite/why-tailwind-isn-t-for-me-5c90), and [Tailwind versus BEM](https://thoughtbot.com/blog/tailwind-versus-bem). I agree with many of their points, but I have a different perspective.
 
-In this post I will try to explain the drawbacks when using Tailwind to create a design system, focusing on the technical aspect of the components.
-I'm assuming that the reader is familiar with design systems, React and has basic programming skills. You can read more about design systems [here](https://www.invisionapp.com/inside-design/guide-to-design-systems/) or [here](https://uxdesign.cc/everything-you-need-to-know-about-design-systems-54b109851969).
+I'm focusing on the technical drawbacks of using Tailwind to create design-system components. I assume you're familiar with design systems and React and have basic programming skills. You can read more about design systems [here](https://www.invisionapp.com/inside-design/guide-to-design-systems/) or [here](https://uxdesign.cc/everything-you-need-to-know-about-design-systems-54b109851969).
 
 ### A little bit about my experience
 
-At the time of writing I'm working at Draftbit and our frontend is built on top of [ReasonReact](https://reasonml.github.io/reason-react) using Tailwind. It has ~500 components. The main page, called the `builder` looks like this:
+At the time of writing, I'm working at Draftbit. Our frontend is built on [ReasonReact](https://reasonml.github.io/reason-react) and uses Tailwind. It has about 500 components, and the main page, called the `builder`, looks like this:
 
 ![screenshot-draftbit-builder](/images/draftbit-builder.png)
 
-I have also contributed to a few design systems in my career, even written my own.
+I have also contributed to a few design systems in my career and even written my own.
 
-I'm obsessed with the conjunction of component-driven design with functional programming and how these enable the writing of modular UIs.
-
-But now, let's talk about Tailwind.
+I'm obsessed with the conjunction of component-driven design and functional programming, and how they enable modular UIs.
 
 ### First, the good parts
 
-The reason I think Tailwind is amazing has nothing to do with the patterns of utility classes. These patterns have been around for a long time, [tachyons](http://tachyons.io/) created around 2016. While some people find them pleasant to use, I personally prefer to write the CSS code directly.
+I think Tailwind is amazing, but not because of its utility-class patterns. Those patterns have existed for a long time. [tachyons](http://tachyons.io/) was created around 2016. Some people find utility classes pleasant to use, though I prefer to write CSS directly.
 
-The reasons why I think Tailwind shines are:
+I think Tailwind shines for these reasons:
 
-- **Theme with strong defaults, beautiful and scalar**: The config file generates all the values needed to produce a scaled system based on design tokens, like spacing. For example the defaultConfig will generate spacing based on a scale from 0 to 96 that goes from 0px until 24rems. [defaultConfig](https://github.com/tailwindlabs/tailwindcss/blob/master/stubs/defaultConfig.stub.js#L7)
-- **Extendability**: The ability to extend values in the config file allows the possibility to represent any design and propagate the right CSS properties. For example, spacing would generate the values for margins, padding, width, min-height, min-height, etc.
-- **Just CSS** It's not an abstraction, or coupled to any framework. It can be used with minimal setup. All IDE would have support for it, all frontend/fullstack frameworks can integrate easily, there's ton of build tools to optimise performance, because it's just "The Platform". It makes adopation easier and future-proof.
+- **Theme with strong defaults, beautiful and scalar**: The config file generates the values needed for a scaled system based on design tokens such as spacing. For example, the [defaultConfig](https://github.com/tailwindlabs/tailwindcss/blob/master/stubs/defaultConfig.stub.js#L7) generates a spacing scale from 0 to 96, or 0px to 24rem.
+- **Extendability**: Extending values in the config file lets you represent any design and propagate the right CSS properties. Extending spacing, for example, generates values for margins, padding, width, min-height, and min-height.
+- **Just CSS**: It isn't an abstraction or coupled to any framework. You can use it with minimal setup. All IDEs support it, all frontend and fullstack frameworks can integrate it easily, and there are tons of build tools to optimise performance. Because it's just "The Platform," it is easier to adopt and future-proof.
 
 ### How is used in React
 
-I use React as an example, but it is used very similar to any other component-based UI library. In particular, React uses JSX via Babel (or any transpiler) which to transform JSX to function calls and eventually will end up as DOM elements.
+I use React as an example, but Tailwind works similarly with any other component-based UI library. React uses JSX through Babel or another transpiler, which transforms JSX into function calls and eventually DOM elements.
 
-During this transformation `className` gets renamed to `class` (since it's a reserved keyword in JavaScript) which applies CSS classes to elements.
+During rendering, React maps the `className` prop to the HTML `class` attribute, which applies CSS classes to the element.
 
-This is the de facto method to use Tailwind with React. For example you will often see:
+This is the de facto way to use Tailwind with React. You will often see:
 
 ```jsx
 <div className="flex md:block w-32 h-full" />
@@ -57,34 +54,33 @@ This is the de facto method to use Tailwind with React. For example you will oft
 
 ### Hard to maintain
 
-Removing one of the `classNames` from the list is error-prone.
-It is like removing an unused CSS class in an [append only stylesheet](https://css-tricks.com/oh-no-stylesheet-grows-grows-grows-append-stylesheet-problem). They can collide with and override other properties.
+Removing one of the `classNames` from a list is error-prone. It resembles removing an unused CSS class from an [append only stylesheet](https://css-tricks.com/oh-no-stylesheet-grows-grows-grows-append-stylesheet-problem): classes can collide with and override other properties.
 
-There're a lot of tools to solve that particular issue, such as linters or editor plugins. But it's still a problem.
+Linters and editor plugins can address that particular issue, but the problem remains.
 
-Aside from being hard to remove, Tailwind classes are hard to change. Adding classes might seem simple and fast while creating components, but it will slow you down when modifying or refactoring them; when your component comprises nested elements created with many Tailwind utilities you won’t be able to safely refactor your structure.
+Tailwind classes are also hard to change. Adding them can seem simple and fast when you create a component, but they slow you down when you modify or refactor it. Once your component has nested elements with many Tailwind utilities, you can't safely refactor its structure.
 
 ### It is optimised for writing, not for reading
 
-When reading JSX, I feel comfortable to imagine a 1-to-1 match with the UI. I can easily navigate thought the component tree and map with the real-world interface.
+When I read JSX, I can comfortably imagine a one-to-one match with the UI. I can navigate the component tree and map it to the real-world interface.
 
 ![screenshot-jsx-sketch-UI](/images/jsx-ui.jpeg)
 
-This UI is doable in Tailwind, but at some level, within the components you will find a layer with a bunch of `classNames` that you need to first parse in your head in order to imagine the UI.
+You can build this UI in Tailwind, but somewhere inside the components you will find a layer packed with `classNames`. You first have to parse them in your head to imagine the UI.
 
-There's a famous quote floating around... **"Best code isn't optimised to be written, instead, it's optimised to be read"**.
+There's a famous quote floating around: **"Best code isn't optimised to be written, instead, it's optimised to be read"**.
 
 ### Fails at dynamic styling
 
-**Dynamic Styling** means having a component that exposes the possibility to change its style based on a prop. These props, are often called **variants**. For example, a button component might have a `variant` prop that can be `primary`, `secondary`, `tertiary`, etc.
+**Dynamic Styling** means exposing a prop that changes a component's style. These props are often called **variants**. For example, a button component might have a `variant` prop that accepts `primary`, `secondary`, `tertiary`, and so on.
 
-This `dynamic styling` is a common pattern in design systems and it's hard to achieve with Tailwind. Since you would need to re implement the same Tailwind tokens as variables, make a mapping between those variants and the Tailwind classes and then apply them to the component.
+This `dynamic styling` pattern is common in design systems and hard to achieve with Tailwind. You need to reimplement the same Tailwind tokens as variables, map the variants to Tailwind classes, and then apply those classes to the component.
 
-Creating a component API that is coherent, versatile and scoped is relatively hard in itself. Doing so requires a good understanding of the problems that the component is trying to solve. So, allowing styling values to be driven by Tailwind is an added complexity that I found very annoying.
+Creating a coherent, versatile, and scoped component API is already hard. It requires a good understanding of the problems the component is trying to solve. Letting Tailwind drive the styling values adds complexity that I find very annoying.
 
 > There's a definite disconnect between a CSS API and a component API. For a design system, I care more about getting the component one right - [@sarah_federman](https://twitter.com/sarah_federman)
 
-To give a simple example: If you want to create a component with a prop like `gap`. `gap` accepts all the possible spacing values that Tailwind does. Let's see how we do that:
+For a simple example, suppose you want a component with a prop named `gap`. It accepts every spacing value that Tailwind accepts. You would write it like this:
 
 ```jsx
 const Card = (props) => {
@@ -95,25 +91,23 @@ const Card = (props) => {
 <Card gap={3} />;
 ```
 
-Now, our `Card` component accepts the value for paddind which creates a few issues. For instance `gap` could technically be any string, like `"4 flex"` and it will break all the UI.
-If you abuse the usage of `classNames` inside your components, it can be a real pain to implement the intermediate logic between your component API and your Tailwind utility classes.
+The `Card` component now accepts a padding value, which creates a few problems. `gap` could technically be any string, such as `"4 flex"`, and break the entire UI. If you overuse `classNames` inside components, implementing the intermediate logic between your component API and Tailwind utility classes becomes a real pain.
 
 ### Impossible to derive styles
 
-Derived styles are a nice usage of JavaScript values to generate scalar UI. Since Tailwind uses those utilities it's very tempting to use them for your components, making derived values impossible.
+Derived styles use JavaScript values to generate scalar UI. Because Tailwind uses utilities, it's tempting to reuse them in your components, which makes derived values impossible.
 
-For example, having a **`<Link />`** component with `color="text-mono-100"` initially it make sense since `text-mono-100` represents the desired color. But, probably later there will be a need to style the link with a different color on hover. You could add another prop called `hoverColor="text-mono-200"` and call it a day.
-But the fact that `color` is represented in another format it's a nightmare, often UIs derive styles from props. In the example above, you could have a color be their hexadecimal representation `color="#b54c4c"` and derive the `hoverColor` with an 80% of opacity, that would be possible if colors have a hexadecimal representation.
+Consider a **`<Link />`** component that starts with `color="text-mono-100"`, where `text-mono-100` represents the desired color. You may later need a different link color on hover. You could add `hoverColor="text-mono-200"` and call it a day. But representing `color` in another format is a nightmare because UIs often derive styles from props. In this example, you could represent the color in hexadecimal as `color="#b54c4c"` and derive `hoverColor` with 80% opacity. That would be possible if colors had a hexadecimal representation.
 
-The Tailwind atomic language is nice to avoid typing CSS but isn't made for component APIs that use any sort of dynamic theme, making impossible (or very hard) to accomplish generative UI.
+Tailwind's atomic language saves you from typing CSS, but it isn't made for component APIs that use a dynamic theme. It makes generative UI impossible, or at least very hard.
 
-Here's an example [https://hihayk.github.io/shaper](https://hihayk.github.io/shaper/#system-ui,%20sans-serif/1.4/0.8/2.28/0.23/1/0.5/137/43/30/5/0.49/2/false)
+See this example: [https://hihayk.github.io/shaper](https://hihayk.github.io/shaper/#system-ui,%20sans-serif/1.4/0.8/2.28/0.23/1/0.5/137/43/30/5/0.49/2/false)
 
 ![Shaper-by-hayk](/images/shaper.png)
 
 ### Breaks style encapsulation
 
-I consider harmful to allow `className` as a prop on the component's API. This is often done to have flexibility from the outside to enable customisation of your component.
+I consider allowing `className` as a prop in a component API harmful. People often do this to enable external customisation of the component.
 
 ```jsx
 const Button = ({ ...props, className }) => (
@@ -121,39 +115,39 @@ const Button = ({ ...props, className }) => (
 )
 ```
 
-But it's a trap. Designing a closed API for those customisations would battle-test your component and force you to decide on an API that have some boundaries, which is the initial goal of making a component.
+It's a trap. Designing a closed API for those customisations would battle-test your component and force you to define boundaries, which is the original purpose of making a component.
 
-Tailwind doesn't have any opinion on this, but it's very tempting to allow any sort of className from the outside in your `classNames`, given that you need customisation from the outside.
+Tailwind has no opinion on this. Still, when you need external customisation, it's tempting to accept any `className` from outside and add it to your `classNames`.
 
 ### Stack: Example of variants
 
-There're a [lot](https://seek-oss.github.io/braid-design-system/foundations/layout#stack) [of](https://polaris.shopify.com/components/structure/stack) [implementations](https://chakra-ui.com/docs/layout/stack) [of](https://www.framer.com/api/stack/) [Stack](https://v2.grommet.io/stack). That's a screenshot of [mine](https://taco-davesnx.vercel.app/?path=/story/distribute--stack).
+There are a [lot](https://seek-oss.github.io/braid-design-system/foundations/layout#stack) [of](https://polaris.shopify.com/components/structure/stack) [implementations](https://chakra-ui.com/docs/layout/stack) [of](https://www.framer.com/api/stack/) [Stack](https://v2.grommet.io/stack). This is a screenshot of [mine](https://taco-davesnx.vercel.app/?path=/story/distribute--stack).
 
-**Stack** places a list of elements on the Y axis, one on top of the other. It adds consistent spacing between them and moves them horizontally or vertically. It's an abstraction on top of **`flexbox`**, but limited. Those constraints are defined mostly by the designer, having a component that enforces the number of variants it's generally a good thing.
+**Stack** places a list of elements on the Y axis, one above the other. It adds consistent spacing between them and moves them horizontally or vertically. It's a limited abstraction on top of **`flexbox`**. Designers define most of those constraints, and a component that enforces a fixed number of variants is generally a good thing.
 
 ![Stack-documentation-taco](/images/stack.png)
 
 ### Composing at the wrong layer
 
-The key feature of **React** is composition of components. Composition here means the possibility to plug those components like a lego which enables create more complex components based on more simple ones.
+The key feature of **React** is component composition. Here, composition means plugging components together like Lego to create more complex components from simpler ones.
 
-With React, **"components"** are a set of rules that React forces on top of just functions. The rules are simple which enables React to perform many benefits that we take for granted. Those rules, are better explained by _Dan Abramov_ in one of his posts, [Writing resilent components](https://overreacted.io/writing-resilient-components/#writing-resilient-components).
+In React, **"components"** are a set of rules applied on top of functions. Those simple rules let React provide many benefits that we take for granted. *Dan Abramov* explains them better in [Writing resilent components](https://overreacted.io/writing-resilient-components/#writing-resilient-components).
 
-As I mentioned before, appending strings to style your component feels like a step backwards. Composing components that are made to solve one thing, It's the pattern that I trend to prefer.
+As I mentioned before, appending strings to style a component feels like a step backwards. I prefer to compose components that each solve one problem.
 
-The composition of components allows React components, to benefit from
+Component composition gives React components these benefits:
 
-- **Declarative representation of the UI**. Create complex pieces of UI based on smaller ones.
-- **Decoupled**: Isolate UI problems into black boxes that doesn't know anything about it's context.
-- **Variants** Implement variants of the same component, without he need to re-implement different versions.
+- **Declarative representation of the UI**. Create complex pieces of UI from smaller ones.
+- **Decoupled**: Isolate UI problems in black boxes that know nothing about their context.
+- **Variants**: Implement variants of the same component without reimplementing different versions.
 
 ### Example of component composition over Tailwind
 
-Re-implementation of Charkra's UI [Box component](https://chakra-ui.com/docs/layout/box) into a pseudo design-system and Tailwind.
+This is a reimplementation of Charkra's UI [Box component](https://chakra-ui.com/docs/layout/box) in a pseudo design system and Tailwind.
 
 ![Card-from-CharkaUI](/images/card.png)
 
-Here you can see the different approaches to the same UI
+Here are the different approaches to the same UI:
 
 ```jsx
 <Box padding={5} width="320px" border="sm">
@@ -213,33 +207,32 @@ Here you can see the different approaches to the same UI
 
 ### A mention to `@apply`
 
-**`@apply`** is the directive that Tailwind recommend to extract repeated utility patterns. Since it's a static definition, you would only abstract those lists into a CSS file. I don't want to get into much details about it, but it does not solve the problems mentioned before.
+**`@apply`** is the directive Tailwind recommends for extracting repeated utility patterns. Because it's a static definition, it only abstracts those lists into a CSS file. I don't want to get into much detail about it, but it doesn't solve the problems above.
 
 ### When I would use Tailwind again then?
 
-1. **Document-like websites**, styling content that is structured as a big chunk. Using [Tailwind Typography](https://blog.tailwindcss.com/tailwindcss-typography) it does come with good defaults for raw content like a blog or a newsletter.
-2. **Prototyping**, creating a UI that visually doesn't need to be high quality or needs a unique style.
+1. **Document-like websites**, for styling content structured as one large chunk. [Tailwind Typography](https://blog.tailwindcss.com/tailwindcss-typography) provides good defaults for raw content such as a blog or newsletter.
+2. **Prototyping**, when the UI doesn't need to be visually polished or needs a unique style.
 
 ### What should I use instead of Tailwind for my design system?
 
-Not all the teams can have the possibility to invest time on building tooling and design systems to give super-powers to the rest of the engineering team. In fact, create a design system it's often a full-time job.
+Not every team can invest time in building tooling and design systems that give the rest of the engineering team superpowers. Creating a design system is often a full-time job.
 
-But, there's a bunch of people who spend a lot of time thinking about those problems and tried to create a few abstractions that you could benefit from:
+However, many people have spent a lot of time thinking about these problems and creating abstractions you can use:
 
 1. [https://theme-ui.com](https://theme-ui.com/)
 2. [https://rebassjs.org](http://rebassjs.org/)
 3. [https://stitches.dev](https://stitches.dev/)
 4. [https://radix-ui.com](https://radix-ui.com/primitives/docs/overview/introduction)
 
-If you still like what Tailwind offers, I recommend a similar approach that we do at **Draftbit**. Create a tiny layer on top of it: Treat all the Tailwind tokens as code and maintain Tailwind scoped within those components. Abstract those utility components that you found repeated in your code into a more strict version, and minimise Tailwind for your app.
+If you still like what Tailwind offers, I recommend the approach we use at **Draftbit**. Create a thin layer on top of it. Treat all Tailwind tokens as code and keep Tailwind scoped within those components. Turn utility components that repeat in your code into stricter abstractions, and minimise Tailwind in your app.
 
 ### How do I try to do it
 
-Mentioned before that I made my own Design system, which is a set of components that only cares about layout disposition, doesn't contain any opinions about cosmetics and allows to compose those elegantly. It's called **taco**.
+I mentioned earlier that I made my own design system. It's a set of components concerned only with layout disposition. It has no opinions about cosmetics and lets you compose those components elegantly. It's called **taco**.
 
-It's currently still a work in progress, since there's a lot of patterns that aren't solved yet. But I have been using them for all my projects.
-Even that is public, isn't for consumption. I didn't write all of this for a plot-twist to sell my library, but you can use it as an example for inspiration.
+It's still a work in progress because many patterns remain unsolved, but I have used it for all my projects. Although it's public, it isn't for consumption. I didn't write all this as a plot twist to sell my library, but you can use it as inspiration.
 
-[Storybook](https://taco.davesnx.vercel.app/) and repository [https://github.com/davesnx/taco](https://github.com/davesnx/taco).
+[Storybook](https://taco.davesnx.vercel.app/) and repository: [https://github.com/davesnx/taco](https://github.com/davesnx/taco).
 
-I hope this post helps. No tool is perfect but understanding them helps us to use them wisely.
+I hope this post helps. No tool is perfect, but understanding tools helps us use them wisely.

--- a/src/content/posts/tailwind-with-dune.mdx
+++ b/src/content/posts/tailwind-with-dune.mdx
@@ -10,15 +10,15 @@ tags:
   - "dune"
 ---
 
-[Despite not being a great fan](/blog/tailwind-and-design-systems), Tailwind is an extremely popular choice for styling, and if you're building web applications with Melange or any other dune-based system, integrating it is surprisingly easy.
+Tailwind is an extremely popular choice for styling. I'm [not a great fan](/blog/tailwind-and-design-systems), but integrating it into web applications built with Melange or any other dune-based system is surprisingly easy.
 
-This tutorial shows you how to set it up so `dune build` handles both JavaScript compilation and CSS generation in one go. A single watch process carried by dune.
+This tutorial shows you how to set up `dune build` to handle both JavaScript compilation and CSS generation in one go, with dune running a single watch process.
 
 ## Prerequisites
 
-Before we start, you'll need:
+You'll need:
 
-1. A Melange project with dune. If you're starting from scratch, the easiest way is to use [create-melange-app](https://github.com/melange-re/melange-opam-template):
+1. A Melange project with dune. If you're starting from scratch, the easiest option is [create-melange-app](https://github.com/melange-re/melange-opam-template):
 
     ```bash
     npx create-melange-app my-app
@@ -40,13 +40,14 @@ Before we start, you'll need:
       --font-display: "Satoshi", "sans-serif";
     }
     ```
-    Check the [Tailwind documentation](https://tailwindcss.com/docs/installation) for the complete customization.
+
+   Check the [Tailwind documentation](https://tailwindcss.com/docs/installation) for complete customization details.
 
 ## Setting up the dune rules
 
-The trick to making Tailwind work seamlessly with Melange is to use dune's `install` and `rule` stanzas. The `rule` lets you define custom build steps that integrate with dune's dependency tracking and caching.
+Dune's `install` and `rule` stanzas make Tailwind work seamlessly with Melange. The `rule` stanza defines custom build steps that use dune's dependency tracking and caching.
 
-Here's what you need to add to your `dune` file:
+Add this to your `dune` file:
 
 ```dune
 (install
@@ -79,31 +80,31 @@ Here's what you need to add to your `dune` file:
   (run tailwind -i %{input} -o %{target})))
 ```
 
-For more details about rules, check the [dune documentation on rules](https://dune.readthedocs.io/en/stable/reference/dune/rule.html).
+The [dune documentation on rules](https://dune.readthedocs.io/en/stable/reference/dune/rule.html) covers them in more detail.
 
-Now you can generate your CSS with:
+Generate your CSS with:
 
 ```bash
 dune build output.css
 ```
 
-Or if you want to rebuild on changes:
+To rebuild when files change:
 
 ```bash
 dune build --watch output.css
 ```
 
-The generated `output.css` will be in `_build/default/output.css` (relative to your dune file's location) and will contain only the Tailwind utilities you're actually using in your project.
+The generated `output.css` will be in `_build/default/output.css`, relative to the location of your dune file. It will contain only the Tailwind utilities you're using in your project.
 
-Dune will only rebuild `output.css` when one of its dependencies changes, making your builds fast and efficient.
+Dune rebuilds `output.css` only when one of its dependencies changes, which keeps builds fast and efficient.
 
-`dune build` would also run the rule.
+`dune build` also runs the rule.
 
 ## Specifying dependencies
 
-A crucial part of dune rules is explicitly declaring what your rule depends on. When any of these dependencies change, dune will automatically re-run the rule.
+Explicitly declaring what your rule depends on is a crucial part of dune rules. When any of these dependencies change, dune automatically reruns the rule.
 
-In our Tailwind setup, we use `(source_tree .)` to watch the entire source tree. This is important because Tailwind scans your source files for class names to determine which CSS to generate. When you add a new class to your code, Tailwind needs to regenerate the CSS.
+In our Tailwind setup, we use `(source_tree .)` to watch the entire source tree because Tailwind scans your source files for class names to determine which CSS to generate. When you add a new class to your code, Tailwind needs to regenerate the CSS.
 
 Dune supports many types of dependencies beyond `source_tree`:
 
@@ -130,13 +131,13 @@ With the rule above, your `output.css` will be in `_build/default/output.css`. Y
 </html>
 ```
 
-This works, but knwoing the file structure under `_build` can feel a bit awkward. That's where promotion comes in.
+This works, but knowing the file structure under `_build` can feel a bit awkward. That's where promotion comes in.
 
 ## Promotion
 
-By default, dune generates files in the `_build` directory by replicating your folder structure and store build metadata.
+By default, dune generates files in the `_build` directory by replicating your folder structure and storing build metadata.
 
-In this case, you want the generated `output.css` to appear in your source tree (so you can reference it directly in your HTML). That's "promotion" (promote the file to your source code). Enabled with `(mode promote)` into to a rule:
+In this case, you want the generated `output.css` to appear in your source tree so you can reference it directly in your HTML. Dune calls this "promotion," which promotes the file to your source code. Add `(mode promote)` to the rule:
 
 ```dune
 (rule
@@ -150,7 +151,7 @@ In this case, you want the generated `output.css` to appear in your source tree 
  (mode promote))
 ```
 
-Now when you run `dune build`, the `output.css` will be copied to your source directory alongside your `dune` file. This makes it easy to reference in your HTML:
+When you run `dune build`, dune copies `output.css` to your source directory alongside your `dune` file. You can then reference it directly in your HTML:
 
 ```html
 <!DOCTYPE html>
@@ -162,11 +163,11 @@ Now when you run `dune build`, the `output.css` will be copied to your source di
 </html>
 ```
 
-The promoted `output.css` file will be regenerated whenever your Tailwind config or input styles change, keeping your styling in sync with your code.
+Dune regenerates the promoted `output.css` file whenever your Tailwind config or input styles change, so your styling stays in sync with your code.
 
 ## Production builds
 
-For production, you'll want the `--minify` flag to reduce file size. You can use dune aliases to have separate development and production builds:
+For production, add the `--minify` flag to reduce file size. You can use dune aliases to create separate development and production builds:
 
 ```dune
 (rule
@@ -180,12 +181,12 @@ For production, you'll want the `--minify` flag to reduce file size. You can use
  (mode promote))
 ```
 
-During development, run `dune build --watch`. For production, run `dune build @prod` which generates a minified `output.min.css`.
+During development, run `dune build --watch`. For production, run `dune build @prod`, which generates a minified `output.min.css`.
 
-Aliases are just one way to handle this. You could also use [`enabled_if`](https://dune.readthedocs.io/en/stable/reference/dune/rule.html#enabled-if) to conditionally enable rules based on environment variables or other conditions.
+Aliases are one way to handle this. You could also use [`enabled_if`](https://dune.readthedocs.io/en/stable/reference/dune/rule.html#enabled-if) to conditionally enable rules based on environment variables or other conditions.
 
 ---
 
-That's the setup: `dune build` now handles your Melange compilation and Tailwind CSS generation together, with proper dependency tracking and caching.
+With this setup, `dune build` handles your Melange compilation and Tailwind CSS generation together, with proper dependency tracking and caching.
 
 Happy hacking with Melange!

--- a/src/content/posts/whats-possible-with-melange.mdx
+++ b/src/content/posts/whats-possible-with-melange.mdx
@@ -10,63 +10,63 @@ tags:
   - "Reason"
 ---
 
-[Melange](https://melange.re) is a backend for the OCaml compiler that emits readable, modular and highly performant JavaScript code. It’s integrated with all OCaml-related tooling such as opam to install packages and dune as a build system.
+[Melange](https://melange.re) is a backend for the OCaml compiler that emits readable, modular, and highly performant JavaScript code. It integrates with all OCaml-related tooling, such as opam for installing packages and dune for building projects.
 
-This blog post provides an overview of what's possible to do with Melange and dune that wasn't possible with a previous toolchain (ReScript v9).
+This post gives an overview of what Melange and dune make possible that the previous toolchain, ReScript v9, did not.
 
-This blog post isn't a direct comparison between Melange v2 and ReScript v9 (also know as BuckleScript) compilers, it wouldn’t be fair since ReScript v9 is not the latest version and their goals were not designed to solve any of the problems Melange solves.
+It isn't a direct comparison between the Melange v2 and ReScript v9 compilers. ReScript v9, also known as BuckleScript, is not the latest version, and its goals did not include solving the problems Melange solves.
 
-Melange started as a fork of BuckleScript but focusing in OCaml compatibility while ReScript continued the integration with JavaScript ecosystem.
+Melange started as a fork of BuckleScript focused on OCaml compatibility, while ReScript continued to integrate more closely with the JavaScript ecosystem.
 
 ## Works with the latest versions of OCaml
 
-One blocker for some OCaml developers adopting ReScript is that it uses an old version (4.06) of the OCaml typechecker, which is several versions behind the latest OCaml release (5.1) at the moment of writing.
+One blocker for some OCaml developers adopting ReScript is its use of an old version of the OCaml typechecker, 4.06. At the time of writing, that is several versions behind the latest OCaml release, 5.1.
 
-This was an issue in our backend as well, since some packages needed to be compatible with 4.06 and 5.1, and a lot has changed:
+This was also an issue in our backend because some packages needed to support both 4.06 and 5.1. A lot has changed between those versions:
 
 - Improvements in type-checking (GADTs, local modules, type variables)
-- [Binding operators (let*, let+, and*, let.async, let.opt, etc…)](https://v2.ocaml.org/releases/4.11/htmlman/bindingops.html)
+- [Binding operators (let\*, let+, and\*, let.async, let.opt, etc…)](https://v2.ocaml.org/releases/4.11/htmlman/bindingops.html)
 - [A new quoted extension syntax](https://github.com/ocaml/ocaml/pull/8820)
 - [Support for macOS/arm64](https://github.com/ocaml/ocaml/pull/9699)
 - Improved error messages
 - [Many](https://ocaml.org/releases/4.09.1) [many](https://ocaml.org/releases/4.10.1) [bug](https://ocaml.org/releases/4.11.0) [fixes](https://ocaml.org/releases/4.12.0)
 - [Tail modulo cons (TMC) optimisation](https://v2.ocaml.org/manual/tail_mod_cons.html)
 
-Side note: A few features of those years of OCaml development don't apply to Melange. In fact, OCaml 5 introduced long-awaited `multicore` features. Currently multicore isn’t a feature supported by Melange since it can’t benefit extensively, due to the nature of JavaScript being single threaded.
+Side note: A few features from those years of OCaml development don't apply to Melange. OCaml 5 introduced the long-awaited `multicore` features, for example. Melange does not currently support multicore because it cannot benefit extensively from it, given JavaScript's single-threaded nature.
 
 ## Editor integration
 
-Using the latest versions of the OCaml compiler allows to use the OCaml LSP Server from the OCaml Platform. It's mature, well maintained and has better support for editor features such as autocompletion, refactoring, type lenses, documentation lookup, debugging of the transformed ppx output and an ast explorer.
+Using the latest versions of the OCaml compiler also lets us use the OCaml LSP Server from the OCaml Platform. It's mature, well maintained, and has better support for editor features such as autocompletion, refactoring, type lenses, documentation lookup, debugging transformed ppx output, and an AST explorer.
 
 ![Screenshot of VSCode with OCaml LSP](/images/melange-editor.png)
 
-One of my favourite features are type lenses.
+One of my favourite features is type lenses.
 
-The previous story of the LSP in BuckleScript/Reason was a tragedy. The editor integration was limited, buggy and even when ReScript started their editor integration was lacking the basics. Worth mentioning, further versions of ReScript has improved this massively but still very far from the OCaml LSP.
+The previous LSP story in BuckleScript/Reason was a tragedy. Editor integration was limited and buggy. When ReScript started its own editor integration, it lacked the basics. Later versions of ReScript have improved this massively, but it is still very far from the OCaml LSP.
 
-A quality of life improvement is allowing to use the same editor to write both Melange and OCaml code, removing the need to switch between different editors when working with both targets.
+Using the same editor for both Melange and OCaml code is a quality-of-life improvement. There is no need to switch editors when working with both targets.
 
 ## Dune is a great build tool
 
-Dune is the defacto build tool for OCaml development these days. Generally speaking, it’s a wrapper to all OCaml tooling such as the Batch compiler (ocamlc), the Native compiler (ocamlopt), also a library manager, etc... It abstracts away those low level tools for users to be in a higher level to define their libraries, executables, testing suites, documentation and other pieces needed to develop a full application.
+Dune is the de facto build tool for OCaml development these days. Generally speaking, it wraps OCaml tooling such as the Batch compiler (`ocamlc`) and Native compiler (`ocamlopt`), and it also manages libraries. It abstracts those low-level tools so users can define their libraries, executables, test suites, documentation, and the other pieces needed to develop a full application at a higher level.
 
-- Dune allows to rebuild your project smartly, only the libraries that change
-- Which means, it would only compile your opam dependencies once (from the same switch)
-- Dune won't rebuild dependent code when an interface hasn't changed
-- Dune also builds in parallel as much as possible
-- Integrates with the rest of the OCaml ecosystem, for example ppxlib or menhir.
+- Dune rebuilds only the libraries that change.
+- This means it compiles your opam dependencies only once from the same switch.
+- Dune won't rebuild dependent code when an interface hasn't changed.
+- Dune also builds in parallel as much as possible.
+- It integrates with the rest of the OCaml ecosystem, including ppxlib and menhir.
 
-It also has been expanded to support other platforms than just native OCaml programs such as [js_of_ocaml](https://github.com/ocsigen/js_of_ocaml), [coq](https://coq.inria.fr/), [to binding C libraries](https://michael.bacarella.com/2022/02/19/dune-ctypes/), [unikernels with MirageOS](https://mirage.io/) and now Melange.
+Dune has expanded beyond native OCaml programs to support other platforms, including [js_of_ocaml](https://github.com/ocsigen/js_of_ocaml), [coq](https://coq.inria.fr/), [binding C libraries](https://michael.bacarella.com/2022/02/19/dune-ctypes/), [unikernels with MirageOS](https://mirage.io/), and now Melange.
 
-Dune deserves most of the credit for the features I'm attributing to Melange. Will try to list the ones I appreciate the most.
+Dune deserves most of the credit for the features I'm attributing to Melange. The following are the ones I appreciate most.
 
 ## Dune gives control to organize your libraries as you wish
 
-The [library stanza](https://dune.readthedocs.io/en/stable/dune-files.html#library) is useful to split your application into smaller pieces and create a better organisation of your codebase. Those libraries can be defined with their own set of dependencies and ppx’s. This is extremely useful for any application older than 1 month and almost a necessity for a monorepo or big application.
+The [library stanza](https://dune.readthedocs.io/en/stable/dune-files.html#library) lets you split your application into smaller pieces and organize the codebase more clearly. Each library can have its own dependencies and ppx's. This is extremely useful for any application older than one month and almost a necessity for a monorepo or large application.
 
-Previously, with ReScript you had one big namespace requiring all module names to be unique, all dependencies and ppx's were applied to the entire codebase. There are some ways to define libraries and define namespaces but they are rarely used since they are buggy and broken.
+With ReScript, you previously had one large namespace that required every module name to be unique. All dependencies and ppx's applied to the entire codebase. ReScript has ways to define libraries and namespaces, but they are rarely used because they are buggy and broken.
 
-As an anecdote, in the ahrefs monorepo we had a bunch of sub-applications that are separated by boundary (Keywords Explorer, Site Audit, etc…) but since it needed to share the unique global namespace, it forced us to prefix all files by an acronym. So, all files from Keyword Explorer would be prefixed with `Ke`, Header becomes `KeHeader`, Table becomes `KeTable`, and so on… to avoid collisions.
+As an anecdote, our Ahrefs monorepo contained many sub-applications separated by boundaries such as Keywords Explorer and Site Audit. Because they shared one global namespace, we had to prefix every file with an acronym. All files from Keyword Explorer used the `Ke` prefix: Header became `KeHeader`, Table became `KeTable`, and so on to avoid collisions.
 
 ```
 $ ls frontend/packages/keywords-explorer/components/
@@ -96,13 +96,13 @@ KeWidgetContent_Css.re  KeWidgetContent.re              KeWidgetHeader_Css.re   
 KeWidgetPlaceholder.re  KeWidgetPlaceholder_Css.re      KeWidgetPreloader_Css.re    KeWidgetPreloader.re
 ```
 
-The unique namespace works great for small applications, but when your codebase is big it becomes quite challenging to manage and not lose your hair. Aside, all dependencies/ppx's were applied to the entire monorepo, which made no-sense and caused issues all around.
+The unique namespace works well for small applications, but it becomes challenging to manage in a large codebase without losing your hair. All dependencies and ppx's also applied across the entire monorepo, which made no sense and caused problems throughout it.
 
-Since Melange, each app can drop the prefix and started to modularise each sub-application with logical boundaries instead, making sure each set of dependencies and ppx's are correctly scoped.
+With Melange, each app can drop its prefix and modularise each sub-application along logical boundaries instead. Each set of dependencies and ppx's is now scoped correctly.
 
 ## Enables universal code
 
-When I say “universal code” I refer to code that’s able to compile to both native and JavaScript. It’s useful for fullstack Reason development and a variety of use-cases, such as:
+When I say “universal code,” I mean code that can compile to both native code and JavaScript. It is useful for fullstack Reason development and a variety of use cases:
 
 - Type-safe data across client/server
 - Universal routing with type-safe routes, links and parameters
@@ -110,52 +110,51 @@ When I say “universal code” I refer to code that’s able to compile to both
 - [Server rendering via server-reason-react](blog/server-side-rendering-react-in-ocaml)
 - RPC (Remote Procedure Call) approach
 
-This has been one of the promises by Reason (and BuckleScript) since the beginning and it never materialised. I have seen some forms of this, but BuckleScript and dune never played well together.
+This has been one of Reason's, and BuckleScript's, promises since the beginning, but it never materialised. I have seen some forms of it, but BuckleScript and dune never worked well together.
 
-Now dune supports a new `melange` mode available for libraries, alongside with `native` mode, enabling universal code.
+Dune now supports a new `melange` mode for libraries alongside `native` mode, enabling universal code.
 
-Given a library without any system dependency (C bindings, unix module, etc) you are able to use it to emit JavaScript and run as an executable.
+Given a library without any system dependency (C bindings, unix module, etc), you can use it to emit JavaScript and run it as an executable.
 
-Some parts of this are still in the design phase, but some more documentation has been written in the server-reason-react documentation:
-[How to organise the universal code](https://ml-in-barcelona.github.io/server-reason-react/local/server-reason-react/code-structure.html) &
-[Make sure your code is universal](https://ml-in-barcelona.github.io/server-reason-react/local/server-reason-react/universal-code.html).
+Some parts are still in the design phase, but more has been written in the server-reason-react documentation: [How to organise the universal code](https://ml-in-barcelona.github.io/server-reason-react/local/server-reason-react/code-structure.html) and [Make sure your code is universal](https://ml-in-barcelona.github.io/server-reason-react/local/server-reason-react/universal-code.html).
 
 ![Example of a react component rendered with both reason-react and server-reason-react](/images/server-reason-react-graph.png)
 
 ## Preprocessing via ppx becomes better and faster
 
-ReScript doesn’t recommend the usage of ppx's and has been looking to replace them since the split. Their reasoning is valid: they are a blackbox, are limited, slows the compilation and are hard to implement right.
+ReScript doesn't recommend using ppx's and has been looking to replace them since the split. Its reasoning is valid: ppx's are a black box, are limited, slow compilation, and are hard to implement correctly.
 
-On the Melange side, the approach is the opposite. Empower ppx’s via [ppxlib](https://github.com/ocaml-ppx/ppxlib) and dune, which they integrate smoothly. [ppxlib](https://github.com/ocaml-ppx/ppxlib) is the framework to create high quality preprocessors, it also integrates perfectly with dune via `(preprocess ...)` and also:
+Melange takes the opposite approach by empowering ppx's through [ppxlib](https://github.com/ocaml-ppx/ppxlib) and dune, which integrate smoothly. [ppxlib](https://github.com/ocaml-ppx/ppxlib) is the framework for creating high-quality preprocessors. It integrates with dune through `(preprocess ...)` and offers several other benefits:
 
-- **Ppx runs faster**. No need to serialise/deserialise the AST on each ppx call, neither run a binary.
-- Ppx are smarter. Dune has a few methods to make ppx run in a single pass, and ppxlib allows to create context free transformations. Making sure rewrites don’t do unnecessary work.
-- No need to distribute pre-built binaries. ppx's are dune libraries, and no need to have GitHub actions to create per-distribution artifacts.
-- This gives us compatibility with more distributions such as M1, M2, any linux distro and even Windows.
-- Access to all [ppx's from opam](https://ocaml.org/packages/search?q=ppx_), such as [ppx_enumerate](https://ocaml.org/p/ppx_enumerate/latest), [ppx_log](https://ocaml.org/p/ppx_log/latest), [ppx_expect](https://ocaml.org/p/ppx_expect/latest), [ppx_inline_test](https://ocaml.org/p/ppx_inline_test/latest), [ppx_blob](https://ocaml.org/p/ppx_blob/latest), [ppx_fields_conv](https://ocaml.org/p/ppx_fields_conv/latest), [ppx_yojson_conv](https://ocaml.org/p/ppx_yojson_conv/latest), [ppx_deriving_rpc](https://ocaml.org/p/ppx_deriving_rpc/latest).
-<sup>Some of this ppx's still need to support melange, and aren't available out of the box</sup>
+- **Ppx runs faster.** There is no need to serialise and deserialise the AST on each ppx call or run a binary.
+- Ppx's are smarter. Dune has methods that run ppx's in a single pass, while ppxlib supports context-free transformations. Rewrites therefore avoid unnecessary work.
+- There is no need to distribute pre-built binaries. Ppx's are dune libraries, so GitHub Actions do not need to create artifacts for each distribution.
+- This provides compatibility with more distributions, including M1, M2, any Linux distro, and even Windows.
+- We have access to all [ppx's from opam](https://ocaml.org/packages/search?q=ppx_), such as [ppx_enumerate](https://ocaml.org/p/ppx_enumerate/latest), [ppx_log](https://ocaml.org/p/ppx_log/latest), [ppx_expect](https://ocaml.org/p/ppx_expect/latest), [ppx_inline_test](https://ocaml.org/p/ppx_inline_test/latest), [ppx_blob](https://ocaml.org/p/ppx_blob/latest), [ppx_fields_conv](https://ocaml.org/p/ppx_fields_conv/latest), [ppx_yojson_conv](https://ocaml.org/p/ppx_yojson_conv/latest), and [ppx_deriving_rpc](https://ocaml.org/p/ppx_deriving_rpc/latest).
+
+<sup>Some of these ppx's still need to support Melange and aren't available out of the box.</sup>
 
 ## Different configs for development and production
 
-Seems basic to showcase this, but previously in BuckleScript you can’t setup different config for production and development. That’s not the case for dune, where you are able to have different [profiles](https://dune.readthedocs.io/en/stable/dune-files.html#profile) and set everything you need differently. Warnings, instrumentation and some libraries are the most common to load differently.
+This may seem like a basic feature to showcase, but BuckleScript could not use different configurations for production and development. Dune can. Its [profiles](https://dune.readthedocs.io/en/stable/dune-files.html#profile) let you configure everything differently for each environment. Warnings, instrumentation, and libraries are the most common differences.
 
-Previously we had a script that generates the config by certain parameter and accomplish such a basic functionality.
+Previously, we had a script that generated the configuration from a parameter to provide this basic functionality.
 
 ## Integration with documentation tooling (odoc)
 
-The other benefit of integrating with the OCaml platform is the documentation tooling is available. It’s called [**odoc**](https://github.com/ocaml/odoc) and it will generate a documentation website from your interface files, with navigation, cross-linking and other utilities.
+Integration with the OCaml Platform also makes its documentation tooling available. [**odoc**](https://github.com/ocaml/odoc) generates a documentation website from your interface files, complete with navigation, cross-linking, and other utilities.
 
-The other cool thing is that it can eventually be published under ocaml.org, for example [ocaml.org/p/melange-json](https://ocaml.org/p/melange-json/latest).
+It can eventually be published on ocaml.org. See [ocaml.org/p/melange-json](https://ocaml.org/p/melange-json/latest), for example.
 
 ## Downsides
 
-Those are massive improvements and gives the possibility to create a new way of working with Reason, currently at ahrefs we have been exploring many ways of pushing this environment forward. With that being said, there are a few downsides from the lenses of ReScript.
+These are massive improvements that make a new way of working with Reason possible. At Ahrefs, we have been exploring many ways to push this environment forward. There are still a few downsides from a ReScript perspective.
 
 ## Learning a new tool
 
-The dune integration brings power to users, but with a cost of learning a new tool, **dune**. Even being powerful, it’s also has a few rough edges, and the learning about those might be noticeable.
+Dune gives users more power at the cost of learning a new tool. Despite its capabilities, dune also has rough edges, and learning about them takes noticeable effort.
 
-The initial blocker might be their syntax, which is very lisp-y. Hopefully your editor can support colorized parentesis to overcome it.
+The initial blocker may be its very Lisp-like syntax. Hopefully, your editor supports colorized parentheses to help with it.
 
 ```clojure
 (library
@@ -164,41 +163,41 @@ The initial blocker might be their syntax, which is very lisp-y. Hopefully your 
  (libraries uri js))
 ```
 
-It’s maintained by [Jane Street](https://www.janestreet.com/), [Tarides](https://tarides.com/), [OCamlPro](https://ocamlpro.com) where they improve it frequently and they are [open for feedback and feature requests](https://discuss.ocaml.org/t/dune-wish-list-for-2023/11083).
+[Jane Street](https://www.janestreet.com/), [Tarides](https://tarides.com/), and [OCamlPro](https://ocamlpro.com) maintain dune, improve it frequently, and are [open to feedback and feature requests](https://discuss.ocaml.org/t/dune-wish-list-for-2023/11083).
 
-After working with it almost 10 months I’m convinced that it’s a big improvement over previous status.
+After working with it for almost 10 months, I'm convinced it is a big improvement over the previous situation.
 
 To learn more about dune specifically, I recommend → [A handy guide to Dune](https://mukulrathi.com/ocaml-tooling-dune/)
 
 ## Different package manager: opam
 
-The recommended package manager for Melange development is **opam**. **opam** is OCaml's package manager (think of npm, rubygems, pip, cargo) and compiler version manager (nvm, rvm, …). In opam, those compiler version plus the dependencies are called switches.
+The recommended package manager for Melange development is **opam**. **opam** is OCaml's package manager, comparable to npm, RubyGems, pip, and cargo, and its compiler version manager, comparable to nvm and rvm. In opam, a compiler version and its dependencies form a switch.
 
-Again, a new tool. It has a few key differences from **npm** based on a safer model:
+It is another new tool, with a few key differences from **npm** based on a safer model:
 
-- **Safer**. The premise of opam is to ensure that after a successful installation, the project will compile correctly.
-- **More strict**. You only can have on single version of a dependency on your project
-- **but slower**. Since it downloads and builds all dependencies from source, the installation takes much longer than npm since it does a bunch of more work.
+- **Safer.** Opam aims to ensure that the project will compile correctly after a successful installation.
+- **More strict.** You can have only one version of a dependency in your project.
+- **But slower.** Opam downloads and builds all dependencies from source, so installation takes much longer than npm because it does more work.
 
 ## Most advances from ReScript won’t be available
 
-ReScript is evolving at a fast pace towards better interoperability with JavaScript and getting ready to compete with TypeScript in terms of features. The ReScript team is working on v11 which includes an impressive list of features such as:
+ReScript is evolving quickly toward better JavaScript interoperability and preparing to compete with TypeScript on features. The ReScript team is working on v11, which includes an impressive list of features:
 
 - Extensible records
 - Variants representation as strings
 - async/await keywords
 - uncurry by default
 
-Those features aren’t possible to implement or support with the same design in Melange, since it would mean breaking compatibility with OCaml and all the ecosystem.
+Those features cannot be implemented or supported with the same design in Melange because doing so would break compatibility with OCaml and its entire ecosystem.
 
 ## Final words
 
-I’m particularly excited about exploring universal code further, and came up with solutions that I wish existed when I started working with Reason. If you are passionate about this, DM me and let’s work together!
+I'm particularly excited about exploring universal code further, and I've come up with solutions I wish had existed when I started working with Reason. If you are passionate about this, DM me and let's work together!
 
-The “benefits” are very clear based on the experience of using Melange in our ahrefs codebase and other projects. If you are curious about Melange, take a look at the [Getting started guide](https://melange.re/v2.1.0/getting-started)
+The “benefits” are very clear from our experience using Melange in the Ahrefs codebase and other projects. If you are curious about Melange, take a look at the [Getting started guide](https://melange.re/v2.1.0/getting-started).
 
-For a fast start, take a look at the [Melange opam template](https://github.com/melange-re/melange-opam-template), [read the documentation](https://dune.readthedocs.io/en/latest/melange.html) or read the [Melange book for React developers](https://react-book.melange.re) for a better step-by-step guide.
+For a fast start, try the [Melange opam template](https://github.com/melange-re/melange-opam-template), [read the documentation](https://dune.readthedocs.io/en/latest/melange.html), or read the [Melange book for React developers](https://react-book.melange.re) for a better step-by-step guide.
 
-I would like to thank [Antonio Nuno Monteiro](https://twitter.com/_anmonteiro), [Javier Chávarri](https://twitter.com/javierwchavarri/) and [Rudi](https://twitter.com/rgrinb) for their effort on making all of this possible. Integrating Melange and Dune is just the start.
+I would like to thank [Antonio Nuno Monteiro](https://twitter.com/_anmonteiro), [Javier Chávarri](https://twitter.com/javierwchavarri/), and [Rudi](https://twitter.com/rgrinb) for their work in making all of this possible. Integrating Melange and Dune is just the start.
 
 Thanks again to [Antonio](https://twitter.com/_anmonteiro) for reviewing a draft of this post.


### PR DESCRIPTION
## Summary

- polish the prose in all 12 published blog posts
- tighten structure, transitions, and technical explanations while preserving each post's voice
- preserve frontmatter, links, MDX comments, and code blocks exactly

## Validation

- `npm run ts`
- `npm run build`
- `git diff --check origin/main...HEAD`
- protected-content comparison for all 12 posts

## Notes

Biome excludes MDX files. The repository-wide `npm run lint` command still reports pre-existing diagnostics in unrelated application files; the Next.js production build completed successfully.
